### PR TITLE
feat: add pricing-page-psychology-audit skill

### DIFF
--- a/skills/pricing-page-psychology-audit/.env.example
+++ b/skills/pricing-page-psychology-audit/.env.example
@@ -1,0 +1,26 @@
+# ─────────────────────────────────────────────────────────────
+# pricing-page-psychology-audit — Environment Variables
+# ─────────────────────────────────────────────────────────────
+#
+# NO API KEYS REQUIRED.
+# This skill uses only requests + BeautifulSoup4 to scrape.
+# All analysis is done by the AI agent using scraped text.
+#
+# ─────────────────────────────────────────────────────────────
+# OPTIONAL: Proxy support (use if target site blocks direct requests)
+# ─────────────────────────────────────────────────────────────
+
+# HTTP_PROXY=http://your-proxy-host:port
+# HTTPS_PROXY=http://your-proxy-host:port
+
+# ─────────────────────────────────────────────────────────────
+# OPTIONAL: Custom request timeout in seconds (default: 15)
+# ─────────────────────────────────────────────────────────────
+
+# SCRAPE_TIMEOUT=15
+
+# ─────────────────────────────────────────────────────────────
+# OPTIONAL: Custom User-Agent string (override default browser UA)
+# ─────────────────────────────────────────────────────────────
+
+# SCRAPE_USER_AGENT=Mozilla/5.0 ...

--- a/skills/pricing-page-psychology-audit/README.md
+++ b/skills/pricing-page-psychology-audit/README.md
@@ -7,8 +7,8 @@
 > Quick Wins ranked by impact.
 
 [![opendirectory](https://img.shields.io/badge/opendirectory-skill-blue)](https://opendirectory.dev)
-[![version](https://img.shields.io/badge/version-1.0.0-green)](https://github.com/ajaycodesitbetter/opendirectory)
-[![license](https://img.shields.io/badge/license-MIT-orange)](LICENSE)
+[![version](https://img.shields.io/badge/version-1.0.0-green)](https://github.com/Varnan-Tech/opendirectory)
+[![license](https://img.shields.io/badge/license-MIT-orange)](https://opensource.org/licenses/MIT)
 
 ---
 

--- a/skills/pricing-page-psychology-audit/README.md
+++ b/skills/pricing-page-psychology-audit/README.md
@@ -1,0 +1,166 @@
+<img src="https://images.unsplash.com/photo-1551288049-bebda4e38f71?w=1280&h=640&fit=crop&q=80" width="100%" alt="cover" />
+
+# pricing-page-psychology-audit
+
+> Paste any SaaS pricing page URL. Get a full audit against 12 pricing
+> psychology principles — with scores, specific rewrites, and your Top 3
+> Quick Wins ranked by impact.
+
+[![opendirectory](https://img.shields.io/badge/opendirectory-skill-blue)](https://opendirectory.dev)
+[![version](https://img.shields.io/badge/version-1.0.0-green)](https://github.com/ajaycodesitbetter/opendirectory)
+[![license](https://img.shields.io/badge/license-MIT-orange)](LICENSE)
+
+---
+
+## What It Does
+
+Most SaaS pricing pages leave money on the table — not because of bad pricing,
+but because of bad psychology. This skill scrapes any pricing page and audits it
+against 12 proven pricing psychology principles used by companies like Notion,
+Linear, and Vercel.
+
+**12 Principles Audited:**
+
+| # | Principle | What It Checks |
+|---|-----------|----------------|
+| 1 | Anchoring | Is the priciest plan shown first to anchor perception? |
+| 2 | Decoy Effect | Is there a tier that makes the top plan look like great value? |
+| 3 | Loss Aversion Framing | Does copy use "don't lose access" vs purely gain language? |
+| 4 | Feature-vs-Value Naming | Do tiers sell outcomes or just list features? |
+| 5 | Social Proof Placement | Are testimonials/logos visible near the pricing tiers? |
+| 6 | Urgency / Scarcity | Are there "limited time" signals or countdown elements? |
+| 7 | Plan Naming Psychology | Are names aspirational (Growth, Scale) vs generic (Pro, Basic)? |
+| 8 | CTA Button Copy | Do CTAs say "Start closing more deals" vs "Sign up"? |
+| 9 | Free Trial vs Freemium | Is the free offer framed clearly without confusion? |
+| 10 | Price Ending Tactics | Do prices end in 9 ($49) or round ($50)? |
+| 11 | Visual Hierarchy | Is the recommended tier visually distinct (badge, highlight)? |
+| 12 | Guarantee / Trust Signals | Is there a money-back guarantee near the CTA? |
+
+**Output includes:**
+- ✅ / ⚠️ / ❌ score per principle
+- Specific rewrite suggestions per tier
+- **Top 3 Quick Wins** — highest-leverage changes, prioritized by impact vs effort
+
+---
+
+## How It Works
+
+```
+User provides URL
+      ↓
+scripts/scrape_pricing.py fetches and extracts:
+  - Plan names & prices
+  - CTA button copy
+  - Feature list items
+  - Full visible text
+      ↓
+AI evaluates scraped content against 12 psychology principles
+      ↓
+Structured Markdown audit report output
+  + Top 3 Quick Wins
+```
+
+---
+
+## Prerequisites
+
+- Python 3.10+
+- pip packages:
+
+```bash
+pip install requests beautifulsoup4
+```
+
+- Works with: **Claude Code · Gemini CLI · Cursor · Antigravity**
+
+---
+
+## Install
+
+```bash
+npx @opendirectory.dev/skills install pricing-page-psychology-audit
+```
+
+---
+
+## Usage
+
+### Basic audit:
+```
+"Use pricing-page-psychology-audit to audit https://linear.app/pricing"
+```
+
+### More examples:
+```
+"Audit the pricing page at https://notion.so/pricing"
+"Run a psychology audit on https://vercel.com/pricing"
+"What's wrong with https://stripe.com/pricing from a psychology perspective?"
+```
+
+---
+
+## Example Output
+
+```markdown
+# Pricing Page Psychology Audit
+**URL:** https://linear.app/pricing
+**Audited on:** 2026-04-18
+**Overall Score:** 9/12 principles passing
+
+---
+
+## Audit Results
+
+### 1. Anchoring — ✅ Pass
+**What we found:** Enterprise plan is listed last but priced highest at
+custom pricing, creating an anchor that makes the $16/seat Business plan
+feel accessible.
+**Suggestion:** Consider moving Enterprise to first position for stronger
+anchoring effect.
+
+### 2. Decoy Effect — ⚠️ Needs Work
+**What we found:** The Business tier exists between Free and Enterprise
+but is not clearly positioned as the "sweet spot."
+**Suggestion:** Add a "Most Popular" badge to Business and increase visual
+size to activate the decoy effect.
+
+[... 10 more principles ...]
+
+---
+
+## 🏆 Top 3 Quick Wins
+
+**Quick Win #1 — CTA Button Copy**
+Current: "Get started"
+Rewrite to: "Start shipping faster — free"
+Why: Action-outcome CTAs convert 14% higher than generic "Get started" copy.
+
+**Quick Win #2 — Social Proof Placement**
+Current: Logos shown on a separate /customers page
+Rewrite to: Add 3 customer logos directly below the pricing tiers
+Why: Social proof near the decision point reduces purchase anxiety.
+
+**Quick Win #3 — Guarantee / Trust Signal**
+Current: No guarantee mentioned on pricing page
+Rewrite to: Add "30-day money-back guarantee. No questions asked." below CTAs
+Why: Guarantees have been shown to increase conversion by up to 21%.
+```
+
+---
+
+## Project Structure
+
+```
+pricing-page-psychology-audit/
+├── SKILL.md              ← AI instructions (the brain)
+├── README.md             ← This file
+├── .env.example          ← No API keys required
+└── scripts/
+    └── scrape_pricing.py ← Python scraper (requests + BeautifulSoup)
+```
+
+---
+
+## License
+
+MIT — Built by [@ajaycodesitbetter](https://github.com/ajaycodesitbetter)

--- a/skills/pricing-page-psychology-audit/SKILL.md
+++ b/skills/pricing-page-psychology-audit/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: pricing-page-psychology-audit
+description: Audits any SaaS pricing page URL against 12 pricing psychology principles and outputs a ranked improvement report with specific rewrite suggestions and quick wins.
+author: ajaycodesitbetter
+version: 1.0.0
+---
+
+# Pricing Page Psychology Audit
+
+Scrape any SaaS pricing page and audit it against 12 proven pricing psychology
+principles. Get a scored Markdown report with specific rewrite suggestions per
+tier and a "Top 3 Quick Wins" section.
+
+---
+
+## Step 1: Get the Target URL
+
+Ask the user:
+"Which SaaS pricing page should I audit? Share the full URL
+(e.g. https://linear.app/pricing)"
+
+If no URL is provided, stop and ask. Do not proceed without a valid URL
+starting with http:// or https://.
+
+---
+
+## Step 2: Run the Scraper
+
+Run the scraper script with the URL:
+
+```bash
+python scripts/scrape_pricing.py "URL_HERE"
+```
+
+The script outputs structured text to stdout. Capture the output — it contains:
+- Page title
+- All visible text content
+- Button labels (CTAs)
+- Plan names and prices
+- Feature list items
+
+If the script fails (timeout, blocked, invalid URL), tell the user:
+"The page could not be scraped: [error]. Try a different URL or check
+if the site blocks bots."
+
+---
+
+## Step 3: Evaluate Against 12 Psychology Principles
+
+Analyze the scraped content against each principle. For each, assign:
+- ✅ Pass — clearly present and well-executed
+- ⚠️ Needs Work — present but weak or could be improved
+- ❌ Missing — not present at all
+
+### The 12 Principles:
+
+1. **Anchoring** — Is there a high-priced plan shown first or prominently to
+   make others feel cheaper?
+
+2. **Decoy Effect** — Is there a middle-tier plan designed to make the top
+   tier look like better value?
+
+3. **Loss Aversion Framing** — Does copy use "don't miss out", "limited",
+   "you'll lose access" rather than purely gain language?
+
+4. **Feature-vs-Value Naming** — Do plan names/descriptions highlight
+   outcomes ("Close more deals") vs just features ("10 seats")?
+
+5. **Social Proof Placement** — Are testimonials, logos, or user counts
+   shown near pricing tiers (not just on a separate page)?
+
+6. **Urgency / Scarcity Signals** — Is there a countdown timer, limited
+   spots badge, or "offer ends" language?
+
+7. **Plan Naming Psychology** — Are plan names aspirational
+   (Starter/Growth/Scale) vs generic (Basic/Pro/Enterprise)?
+
+8. **CTA Button Copy** — Do CTAs say action-outcome ("Start growing free")
+   vs generic ("Sign up" or "Get started")?
+
+9. **Free Trial vs Freemium Framing** — Is the free offer framed clearly?
+   Does it reduce friction or create confusion?
+
+10. **Price Ending Tactics** — Do prices end in 9 ($49, $99) for perceived
+    value, or round numbers ($50, $100) for premium feel?
+
+11. **Visual Hierarchy of Tiers** — Is the recommended/popular plan visually
+    highlighted (badge, border, size difference)?
+
+12. **Guarantee / Trust Signal Presence** — Is there a money-back guarantee,
+    "no credit card required", or security badge near the CTA?
+
+---
+
+## Step 4: Generate the Audit Report
+
+Output the report in this exact Markdown structure:
+
+```
+# Pricing Page Psychology Audit
+**URL:** [URL]
+**Audited on:** [today's date]
+**Overall Score:** X/12 principles passing
+
+---
+
+## Audit Results
+
+### 1. Anchoring — ✅ Pass / ⚠️ Needs Work / ❌ Missing
+**What we found:** [1-2 sentences from the page]
+**Suggestion:** [Specific rewrite or change to make]
+
+[Repeat for all 12 principles]
+
+---
+
+## 🏆 Top 3 Quick Wins
+
+These are your highest-leverage changes, prioritized by impact vs effort:
+
+**Quick Win #1 — [Principle name]**
+Current: "[exact copy from page]"
+Rewrite to: "[your improved version]"
+Why: [1 sentence on the psychological mechanism]
+
+**Quick Win #2 — [Principle name]**
+...
+
+**Quick Win #3 — [Principle name]**
+...
+```
+
+---
+
+## Step 5: Self-QA Before Output
+
+Check before presenting the report:
+- [ ] All 12 principles are scored (none skipped)
+- [ ] Each "Suggestion" is specific — no generic advice like "add social proof"
+- [ ] Quick Wins cite actual copy from the page (not invented)
+- [ ] Scores reflect what is literally present in the scraped content
+- [ ] Date is today's actual date
+
+Fix any violation before output.
+
+---
+
+## Step 6: Offer Follow-ups
+
+After presenting the report, offer:
+1. "Export this as a PDF-ready Markdown file"
+2. "Generate rewrite copy for all CTAs on this page"
+3. "Compare against a competitor's pricing page"
+4. "Build a prioritized action plan for the dev team"

--- a/skills/pricing-page-psychology-audit/scripts/scrape_pricing.py
+++ b/skills/pricing-page-psychology-audit/scripts/scrape_pricing.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""
+scrape_pricing.py — Pricing Page Scraper
+Part of: pricing-page-psychology-audit skill
+Author: ajaycodesitbetter
+
+Usage:
+    python scripts/scrape_pricing.py "https://linear.app/pricing"
+
+Output:
+    Structured plain-text to stdout for AI analysis.
+    Errors are printed to stderr so stdout stays clean.
+"""
+
+import sys
+import re
+import requests
+from bs4 import BeautifulSoup
+
+
+# ── Constants ────────────────────────────────────────────────────────────────
+
+TIMEOUT_SECONDS = 15
+
+# Rotate user-agent to reduce bot-blocking (no API key needed)
+HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/124.0.0.0 Safari/537.36"
+    ),
+    "Accept-Language": "en-US,en;q=0.9",
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+}
+
+# HTML tags that carry pricing-relevant content
+CONTENT_TAGS = ["h1", "h2", "h3", "h4", "p", "li", "span", "button", "a"]
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+def clean(text: str) -> str:
+    """Strip extra whitespace and blank lines from a string."""
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def validate_url(url: str) -> bool:
+    """Return True if the URL looks valid (starts with http/https)."""
+    return url.startswith("http://") or url.startswith("https://")
+
+
+def fetch_page(url: str) -> str:
+    """
+    Fetch the raw HTML of a URL.
+    Raises a descriptive RuntimeError on failure.
+    """
+    try:
+        response = requests.get(url, headers=HEADERS, timeout=TIMEOUT_SECONDS)
+        response.raise_for_status()
+        return response.text
+
+    except requests.exceptions.MissingSchema:
+        raise RuntimeError(f"Invalid URL format: '{url}'. Include http:// or https://")
+
+    except requests.exceptions.ConnectionError:
+        raise RuntimeError(f"Could not connect to '{url}'. Check the URL or your internet.")
+
+    except requests.exceptions.Timeout:
+        raise RuntimeError(f"Request timed out after {TIMEOUT_SECONDS}s for '{url}'.")
+
+    except requests.exceptions.HTTPError as e:
+        code = e.response.status_code
+        if code == 403:
+            raise RuntimeError(
+                f"Access blocked (HTTP 403) — '{url}' may have bot protection. "
+                "Try opening it in a browser and using the page source manually."
+            )
+        raise RuntimeError(f"HTTP error {code} for '{url}': {e}")
+
+
+# ── Extraction ────────────────────────────────────────────────────────────────
+
+def extract_page_title(soup: BeautifulSoup) -> str:
+    """Get the <title> tag text."""
+    tag = soup.find("title")
+    return clean(tag.get_text()) if tag else "No title found"
+
+
+def extract_buttons(soup: BeautifulSoup) -> list:
+    """
+    Extract all button and CTA link text.
+    Targets <button> tags and <a> tags with common CTA class names.
+    """
+    buttons = []
+
+    # All <button> elements
+    for btn in soup.find_all("button"):
+        text = clean(btn.get_text())
+        if text:
+            buttons.append(text)
+
+    # <a> tags that look like CTAs (common class keywords)
+    cta_keywords = ["btn", "button", "cta", "action", "signup", "start", "trial"]
+    for link in soup.find_all("a", href=True):
+        classes = " ".join(link.get("class", [])).lower()
+        if any(kw in classes for kw in cta_keywords):
+            text = clean(link.get_text())
+            if text:
+                buttons.append(text)
+
+    # Deduplicate while preserving order
+    seen = set()
+    unique = []
+    for b in buttons:
+        if b.lower() not in seen:
+            seen.add(b.lower())
+            unique.append(b)
+
+    return unique
+
+
+def extract_prices(soup: BeautifulSoup) -> list:
+    """
+    Extract price strings using regex on page text.
+    Catches formats like: $49, $49/mo, $49/month, EUR99, GBP19.99, Free
+    """
+    text = soup.get_text(" ", strip=True)
+    price_pattern = re.compile(
+        r"(Free|free|\$[\d,.]+(?:/\w+)?|\u20ac[\d,.]+(?:/\w+)?|\xa3[\d,.]+(?:/\w+)?|"
+        r"[\d,.]+\s*(?:USD|EUR|GBP)(?:/\w+)?)"
+    )
+    matches = price_pattern.findall(text)
+
+    # Deduplicate while preserving order
+    seen = set()
+    unique = []
+    for m in matches:
+        val = m.strip()
+        if val.lower() not in seen:
+            seen.add(val.lower())
+            unique.append(val)
+
+    return unique
+
+
+def extract_plan_names(soup: BeautifulSoup) -> list:
+    """
+    Extract likely plan/tier names from headings and elements
+    with pricing-related class names.
+    """
+    plan_keywords = ["plan", "tier", "pricing", "package"]
+    candidates = []
+
+    # Check headings inside pricing-related sections
+    for tag in soup.find_all(["h2", "h3", "h4"]):
+        parent = tag.find_parent()
+        parent_classes = " ".join(parent.get("class", [])).lower() if parent else ""
+        if any(kw in parent_classes for kw in plan_keywords):
+            text = clean(tag.get_text())
+            if text and len(text) < 50:  # plan names are short
+                candidates.append(text)
+
+    # Also grab standalone headings that look like tier names
+    tier_hints = re.compile(
+        r"^(free|starter|basic|pro|growth|scale|business|enterprise|team|"
+        r"plus|premium|advanced|essentials|standard)$",
+        re.IGNORECASE,
+    )
+    for tag in soup.find_all(["h2", "h3", "h4", "span", "p"]):
+        text = clean(tag.get_text())
+        if tier_hints.match(text):
+            candidates.append(text)
+
+    # Deduplicate
+    seen = set()
+    unique = []
+    for c in candidates:
+        if c.lower() not in seen:
+            seen.add(c.lower())
+            unique.append(c)
+
+    return unique
+
+
+def extract_features(soup: BeautifulSoup) -> list:
+    """
+    Extract feature list items — typically <li> elements inside
+    pricing card sections.
+    """
+    features = []
+    for li in soup.find_all("li"):
+        text = clean(li.get_text())
+        # Feature items are usually one short line
+        if text and 3 < len(text) < 120:
+            features.append(text)
+
+    # Deduplicate
+    seen = set()
+    unique = []
+    for f in features:
+        if f.lower() not in seen:
+            seen.add(f.lower())
+            unique.append(f)
+
+    return unique[:60]  # Cap at 60 to keep output focused
+
+
+def extract_all_text(soup: BeautifulSoup) -> str:
+    """
+    Extract all visible text in document order for full-context analysis.
+    Removes <script>, <style>, <nav>, <footer> noise.
+    """
+    # Remove noisy tags
+    for tag in soup(["script", "style", "nav", "footer", "noscript", "meta"]):
+        tag.decompose()
+
+    lines = []
+    for tag in soup.find_all(CONTENT_TAGS):
+        text = clean(tag.get_text())
+        if text and len(text) > 2:
+            lines.append(text)
+
+    # Deduplicate consecutive duplicates (common in SPAs)
+    deduped = []
+    prev = None
+    for line in lines:
+        if line != prev:
+            deduped.append(line)
+            prev = line
+
+    return "\n".join(deduped)
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+def main():
+    # Validate arguments
+    if len(sys.argv) < 2:
+        print("ERROR: No URL provided.", file=sys.stderr)
+        print("Usage: python scripts/scrape_pricing.py <URL>", file=sys.stderr)
+        sys.exit(1)
+
+    url = sys.argv[1].strip()
+
+    if not validate_url(url):
+        print(f"ERROR: Invalid URL '{url}'. Must start with http:// or https://", file=sys.stderr)
+        sys.exit(1)
+
+    # Fetch the page
+    try:
+        html = fetch_page(url)
+    except RuntimeError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    # Parse HTML
+    soup = BeautifulSoup(html, "html.parser")
+
+    # Extract structured data
+    title      = extract_page_title(soup)
+    buttons    = extract_buttons(soup)
+    prices     = extract_prices(soup)
+    plan_names = extract_plan_names(soup)
+    features   = extract_features(soup)
+    all_text   = extract_all_text(soup)
+
+    # ── Output to stdout (clean structured text for AI) ──────────────────────
+    separator = "\u2500" * 60
+
+    print(f"PAGE TITLE: {title}")
+    print(f"URL: {url}")
+    print(separator)
+
+    print("\n## PLAN NAMES DETECTED")
+    if plan_names:
+        for name in plan_names:
+            print(f"  - {name}")
+    else:
+        print("  (none detected — check page structure)")
+
+    print("\n## PRICES DETECTED")
+    if prices:
+        for price in prices:
+            print(f"  - {price}")
+    else:
+        print("  (none detected — page may use dynamic pricing)")
+
+    print("\n## CTA BUTTON TEXT")
+    if buttons:
+        for btn in buttons:
+            print(f"  - {btn}")
+    else:
+        print("  (none detected)")
+
+    print("\n## FEATURE LIST ITEMS")
+    if features:
+        for feat in features[:30]:  # Show top 30 for readability
+            print(f"  - {feat}")
+    else:
+        print("  (none detected)")
+
+    print(f"\n{separator}")
+    print("## FULL PAGE TEXT (for AI analysis)")
+    print(separator)
+    print(all_text)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/pricing-page-psychology-audit/scripts/scrape_pricing.py
+++ b/skills/pricing-page-psychology-audit/scripts/scrape_pricing.py
@@ -12,6 +12,7 @@ Output:
     Errors are printed to stderr so stdout stays clean.
 """
 
+import os
 import sys
 import re
 import requests
@@ -20,9 +21,9 @@ from bs4 import BeautifulSoup
 
 # ── Constants ────────────────────────────────────────────────────────────────
 
-TIMEOUT_SECONDS = 15
+TIMEOUT_SECONDS = int(os.environ.get("SCRAPE_TIMEOUT", 15))
 
-# Rotate user-agent to reduce bot-blocking (no API key needed)
+# Browser-like headers to reduce bot-blocking (no API key needed)
 HEADERS = {
     "User-Agent": (
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
@@ -32,6 +33,11 @@ HEADERS = {
     "Accept-Language": "en-US,en;q=0.9",
     "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
 }
+
+# Allow env var override of User-Agent (e.g. for custom scraping setups)
+_custom_ua = os.environ.get("SCRAPE_USER_AGENT")
+if _custom_ua:
+    HEADERS["User-Agent"] = _custom_ua
 
 # HTML tags that carry pricing-relevant content
 CONTENT_TAGS = ["h1", "h2", "h3", "h4", "p", "li", "span", "button", "a"]
@@ -76,6 +82,9 @@ def fetch_page(url: str) -> str:
                 "Try opening it in a browser and using the page source manually."
             )
         raise RuntimeError(f"HTTP error {code} for '{url}': {e}")
+
+    except requests.exceptions.RequestException as e:
+        raise RuntimeError(f"Unexpected request error for '{url}': {e}")
 
 
 # ── Extraction ────────────────────────────────────────────────────────────────
@@ -126,7 +135,7 @@ def extract_prices(soup: BeautifulSoup) -> list:
     """
     text = soup.get_text(" ", strip=True)
     price_pattern = re.compile(
-        r"(Free|free|\$[\d,.]+(?:/\w+)?|\u20ac[\d,.]+(?:/\w+)?|\xa3[\d,.]+(?:/\w+)?|"
+        r"(Free|free|\$[\d,.]+(?:/\w+)?|€[\d,.]+(?:/\w+)?|£[\d,.]+(?:/\w+)?|"
         r"[\d,.]+\s*(?:USD|EUR|GBP)(?:/\w+)?)"
     )
     matches = price_pattern.findall(text)


### PR DESCRIPTION
## What this adds

A new AI Agent Skill: `pricing-page-psychology-audit`

Scrapes any SaaS pricing page and audits it against 12 proven pricing psychology principles. Outputs a scored Markdown report with specific rewrite suggestions and a "Top 3 Quick Wins" section.

## Files added

- `SKILL.md` — Step-by-step AI instructions for the audit
- `README.md` — Public docs with cover image, usage examples, example output
- `.env.example` — No API keys required
- `scripts/scrape_pricing.py` — Pure requests + BeautifulSoup scraper

## Tested with
- https://linear.app/pricing
- https://notion.so/pricing

## Checklist
- [x] SKILL.md has valid YAML frontmatter
- [x] README.md has dark-mode cover image as first element
- [x] Python script handles errors gracefully
- [x] No hardcoded credentials
- [x] .env.example included