### PR TITLE
fix: explicit files array in package.json to include README

### DIFF
--- a/packages/cli/.npmignore
+++ b/packages/cli/.npmignore
@@ -1,0 +1,10 @@
+skills/**/*.png
+skills/**/*.jpg
+skills/**/*.jpeg
+skills/**/*.gif
+skills/**/*.webp
+skills/**/node_modules
+skills/**/package-lock.json
+skills/**/yarn.lock
+skills/**/pnpm-lock.yaml
+skills/**/*.env*

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -3,6 +3,11 @@
   "version": "0.1.72",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "skills",
+    "README.md"
+  ],
   "bin": {
     "opendirectory": "dist/index.js"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -6,7 +6,7 @@
   "files": [
     "dist",
     "skills",
-    "README.md"
+    "registry.json"
   ],
   "bin": {
     "opendirectory": "dist/index.js"


### PR DESCRIPTION
This pull request makes a small update to the `package.json` file for the CLI package, specifying which files should be included when the package is published. This helps ensure only the necessary files are distributed.