### PR TITLE
fix: add missing install commands to 4 skills

### DIFF
--- a/skills/linkedin-job-post-to-buyer-pain-map/README.md
+++ b/skills/linkedin-job-post-to-buyer-pain-map/README.md
@@ -123,7 +123,11 @@ linkedin-job-post-to-buyer-pain-map/
 
 MIT
 
-## Installation in Claude Desktop App
+## Install
+
+```bash
+npx "@opendirectory.dev/skills" install linkedin-job-post-to-buyer-pain-map --target claude
+```
 
 ### Video Tutorial
 Watch this quick video to see how it's done:

--- a/skills/meta-tribeV2-skill/README.md
+++ b/skills/meta-tribeV2-skill/README.md
@@ -21,6 +21,10 @@ This skill provides the infrastructure to host the massive 80GB TRIBE v2 model p
 
 ## Install
 
+```bash
+npx "@opendirectory.dev/skills" install meta-tribeV2-skill --target claude
+```
+
 ### Video Tutorial
 Watch this quick video to see how it's done:
 

--- a/skills/oss-launch-kit/README.md
+++ b/skills/oss-launch-kit/README.md
@@ -12,12 +12,57 @@ The high-level **OSS Launch Orchestrator** for GitHub repositories. It serves as
 - **Skill Hand-offs**: Provides hooks and pointers to `show-hn-writer`, `producthunt-launch-kit`, and `reddit-post-engine`.
 - **Honest Feedback**: Explicitly flags low-readiness repos and recommends documentation sprints.
 
-## Usage
+## Install
 
 ```bash
-# Generate a launch strategy and checklist for a repo
-python scripts/run.py --repo-url https://github.com/owner/repo
+npx "@opendirectory.dev/skills" install oss-launch-kit --target claude
 ```
+
+### Video Tutorial
+Watch this quick video to see how it's done:
+
+https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c
+
+### Step 1: Download the skill from GitHub
+1. Click the **Code** button on this repo's GitHub page.
+2. Select **Download ZIP** to download the repository.
+3. Extract the ZIP file on your computer.
+
+### Step 2: Install the Skill in Claude
+1. Open your **Claude desktop app**.
+2. Go to the sidebar on the left side and click on the **Customize** section.
+3. Click on the **Skills** tab, then click on the **+** (plus) icon button to create a new skill.
+4. Choose the option to **Upload a skill**, and drag and drop the `.zip` file (or you can extract it and drop the folder, both work).
+
+> **Note:** Make sure you are uploading the folder that contains the `SKILL.md` file!
+
+---
+
+## How It Works
+
+1. Point the agent at a GitHub repo URL.
+2. The agent analyzes the repo (README, license, install guide, metadata) and scores launch readiness.
+3. You receive a channel recommendation, a timed launch checklist, and skill hand-offs to `show-hn-writer`, `producthunt-launch-kit`, and `reddit-post-engine`.
+
+---
+
+## Usage
+
+```
+"Run a launch readiness check on https://github.com/owner/repo and give me a channel strategy."
+```
+
+```
+"Analyze this repo and create a coordinated launch plan across Product Hunt, HN, and Reddit."
+```
+
+---
+
+## Requirements
+
+- Claude desktop app (no other dependencies)
+
+---
 
 ## Differentiation
 

--- a/skills/vc-curated-match/README.md
+++ b/skills/vc-curated-match/README.md
@@ -10,8 +10,34 @@ The `vc-curated-match` is an OpenDirectory skill that connects founders and open
 
 **Positioning Note**: This skill is intentionally different from live-research investor discovery workflows. It provides deterministic, curated VC matching from a verified static dataset. It is best for fast, low-cost, repeatable first-pass investor targeting.
 
-## Prerequisites
-- Python 3.10+ (Standard Library only)
+## Install
+
+```bash
+npx "@opendirectory.dev/skills" install vc-curated-match --target claude
+```
+
+### Video Tutorial
+Watch this quick video to see how it's done:
+
+https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c
+
+### Step 1: Download the skill from GitHub
+1. Click the **Code** button on this repo's GitHub page.
+2. Select **Download ZIP** to download the repository.
+3. Extract the ZIP file on your computer.
+
+### Step 2: Install the Skill in Claude
+1. Open your **Claude desktop app**.
+2. Go to the sidebar on the left side and click on the **Customize** section.
+3. Click on the **Skills** tab, then click on the **+** (plus) icon button to create a new skill.
+4. Choose the option to **Upload a skill**, and drag and drop the `.zip` file (or you can extract it and drop the folder, both work).
+
+> **Note:** Make sure you are uploading the folder that contains the `SKILL.md` file!
+
+---
+
+## Requirements
+- Python 3.10+ (Standard Library only used internally by the agent)
 
 ## Implementation Specs
 - Pulls from a static `data/vc_funds.json` dataset to guarantee data validity.


### PR DESCRIPTION
Adds npx install command to oss-launch-kit, vc-curated-match, meta-tribeV2-skill, and linkedin-job-post-to-buyer-pain-map READMEs.