### PR TITLE
fix: plugin manifest schema validation + dynamic skill count (Fixes #24)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "opendirectory-gtm-skills",
       "source": "./",
-      "description": "28+ GTM and Marketing Skills"
+      "description": "55 GTM and Marketing Skills"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,148 +1,19 @@
 {
   "name": "opendirectory-gtm-skills",
-  "author": "Varnan",
-  "description": "A collection of GTM skills for Claude Code",
-  "version": "1.0.0",
-  "skills": [
-    {
-      "name": "blog-cover-image-cli",
-      "description": "A skill for blog-cover-image-cli",
-      "path": "./skills/blog-cover-image-cli"
-    },
-    {
-      "name": "claude-md-generator",
-      "description": "Skill for claude-md-generator",
-      "path": "./skills/claude-md-generator"
-    },
-    {
-      "name": "cook-the-blog",
-      "description": "Generate high-converting, deep-dive growth case studies in MDX format. Use this skill when asked to write a case study or blog post about a company's growth, tech stack, or product-led strategy. It handles the full pipeline (researching the company via Tavily, generating a 16:9 cover image, quality checking the draft, uploading assets to cloud storage, and pushing directly to the target repository).",
-      "path": "./skills/cook-the-blog"
-    },
-    {
-      "name": "dependency-update-bot",
-      "description": "Scans your project for outdated npm, pip, Cargo, Go, or Ruby packages. Runs a CVE security audit. Fetches changelogs, summarizes breaking changes with Gemini, and opens one PR per risk group (patch, minor, major). Includes Diagnosis Mode for install conflicts. Use when asked to update dependencies, check for outdated packages, open dependency PRs, scan for package updates, audit for CVEs, or flag breaking changes in upgrades. Trigger when a user says \"check for outdated packages\", \"update my dependencies\", \"open PRs for dependency updates\", \"scan for CVEs\", or \"which packages need upgrading\".",
-      "path": "./skills/dependency-update-bot"
-    },
-    {
-      "name": "docs-from-code",
-      "description": "Generates and updates README.md and API reference docs by reading your codebase's functions, routes, types, schemas, and architecture. Uses graphify to build a knowledge graph first, then writes accurate docs from it. Use when asked to write docs, generate a README, document an API, update stale docs, create an API reference from code, add an architecture section, or document a project in any language. Trigger when a user says their docs are missing, outdated, or wants to document their codebase without writing it manually.",
-      "path": "./skills/docs-from-code"
-    },
-    {
-      "name": "explain-this-pr",
-      "description": "Takes a GitHub PR URL or the current branch and writes a plain-English explanation of what it does and why, then posts it as a PR comment. Use when asked to explain a PR, summarize a pull request, write a plain-English description of a PR, add a summary comment to a PR, or understand what a PR changes. Trigger when a user says \"explain this PR\", \"summarize this pull request\", \"what does this PR do\", \"add a comment explaining the PR\", or shares a GitHub PR URL and asks what it does.",
-      "path": "./skills/explain-this-pr"
-    },
-    {
-      "name": "google-trends-api-skills",
-      "description": "A skill for google-trends-api-skills",
-      "path": "./skills/google-trends-api-skills"
-    },
-    {
-      "name": "hackernews-intel",
-      "description": "Monitors Hacker News for user-configured keywords, deduplicates against a local SQLite cache, and sends Slack alerts for new matching posts. Use when asked to monitor Hacker News for mentions, track keywords on HN, get alerts when something is posted about a topic on Hacker News, or set up HN keyword monitoring. Trigger when a user mentions Hacker News alerts, HN monitoring, keyword tracking on HN, or wants to know when a topic appears on Hacker News.",
-      "path": "./skills/hackernews-intel"
-    },
-    {
-      "name": "kill-the-standup",
-      "description": "Reads yesterday's Linear issues and GitHub commits for the authenticated user, formats a standup update (done / doing / blockers), and posts it to Slack. Use when asked to write a standup, generate a standup update, post to the standup channel, summarize yesterday's work, or automate the daily standup. Trigger when a user says \"write my standup\", \"post standup\", \"generate standup update\", \"what did I do yesterday\", or \"kill the standup\".",
-      "path": "./skills/kill-the-standup"
-    },
-    {
-      "name": "linkedin-post-generator",
-      "description": "Converts any content, blog post URL, pasted article, GitHub PR description, or a description of something built, into a formatted LinkedIn post with proper hook, story arc, and formatting. Optionally posts directly to LinkedIn via Composio. Use when asked to write a LinkedIn post, turn a blog into a LinkedIn update, announce a shipped feature, share a case study on LinkedIn, or post something professionally. Trigger when a user mentions LinkedIn, wants to share content professionally, says \"post this to LinkedIn\", or asks to repurpose a blog/article/PR for social media.",
-      "path": "./skills/linkedin-post-generator"
-    },
-    {
-      "name": "llms-txt-generator",
-      "description": "Generates and maintains a standards-compliant llms.txt file for any website — either by crawling the live site OR by reading the website's codebase directly. Use this skill when asked to create an llms.txt, add AI discoverability to a site, improve GEO (Generative Engine Optimization), make a website readable by AI agents, generate an llms-full.txt, check if a site has llms.txt, or audit a site's AI readiness for generative search. Trigger this skill any time a user mentions llms.txt, AI discoverability, LLM site readability, or wants their site to appear in AI-generated answers. Also trigger when the user is inside a website codebase and asks about SEO, AI readiness, or content structure.",
-      "path": "./skills/llms-txt-generator"
-    },
-    {
-      "name": "luma-attendees-scraper",
-      "description": "A skill for luma-attendees-scraper",
-      "path": "./skills/luma-attendees-scraper"
-    },
-    {
-      "name": "meeting-brief-generator",
-      "description": "Takes a company name and optional contact, runs targeted research via Tavily, synthesizes a 1-page pre-call brief with Gemini, and optionally saves it to Notion. Use when asked to prepare for a meeting, research a prospect before a call, generate a company brief, create a pre-call summary, or write a meeting prep doc. Trigger when a user says \"prepare me for a meeting with\", \"research this company before my call\", \"generate a meeting brief for\", \"I have a call with X tomorrow\", or \"create a prospect brief for\".",
-      "path": "./skills/meeting-brief-generator"
-    },
-    {
-      "name": "meta-ads-skill",
-      "description": "A skill for meta-ads-skill",
-      "path": "./skills/meta-ads-skill"
-    },
-    {
-      "name": "newsletter-digest",
-      "description": "Aggregates RSS feeds from the past week, synthesizes the top stories using Gemini, and publishes a newsletter digest to Ghost CMS. Optionally outputs formatted Markdown for Substack or any other platform. Use when asked to generate a newsletter, create a weekly digest, summarize RSS feeds, compile top stories for a newsletter, or publish a digest to Ghost. Trigger when a user mentions newsletter digest, weekly roundup, RSS digest, compile top stories, or publish to Ghost.",
-      "path": "./skills/newsletter-digest"
-    },
-    {
-      "name": "noise2blog",
-      "description": "Turns rough notes, bullet points, voice transcripts, or tweet dumps into a polished, publication-ready blog post. Optionally enriches with Tavily research to add supporting data and credibility to claims. Use when asked to write a blog post from notes, turn rough ideas into an article, expand bullet points into a full post, clean up a voice transcript into a blog, or repurpose a tweet thread as an article. Trigger when a user says \"write a blog post from this\", \"turn these notes into a post\", \"expand this into an article\", \"make this publishable\", \"I have rough notes write a blog\", or \"clean up this transcript\".",
-      "path": "./skills/noise2blog"
-    },
-    {
-      "name": "outreach-sequence-builder",
-      "description": "Takes a buying signal and generates a personalized multi-channel outreach sequence across email, LinkedIn, and phone. Outputs 4-6 ready-to-send touchpoints over 10-14 days. Optionally drafts email touchpoints via Composio Gmail. Use when asked to write an outreach sequence, build a sales cadence, create a follow-up sequence, personalize outreach for a signal, or generate cold outreach messages. Trigger when a user says \"build an outreach sequence for\", \"write a sales cadence for\", \"create outreach based on this signal\", \"they just raised a round write me a sequence\", or \"generate personalized outreach for\".",
-      "path": "./skills/outreach-sequence-builder"
-    },
-    {
-      "name": "position-me",
-      "description": "A skill for position-me",
-      "path": "./skills/position-me"
-    },
-    {
-      "name": "pr-description-writer",
-      "description": "Skill for pr-description-writer",
-      "path": "./skills/pr-description-writer"
-    },
-    {
-      "name": "producthunt-launch-kit",
-      "description": "Skill for producthunt-launch-kit",
-      "path": "./skills/producthunt-launch-kit"
-    },
-    {
-      "name": "reddit-icp-monitor",
-      "description": "Watches subreddits for people describing the exact problem you solve, scores their relevance to your ICP, and drafts a helpful non-spammy reply for each high-signal post. Use when asked to monitor Reddit for ICP signals, find prospects on Reddit, surface pain point posts, draft helpful Reddit replies, or scan subreddits for buying signals. Trigger when a user says \"monitor Reddit for my ICP\", \"find people on Reddit who need my product\", \"scan subreddits for pain points\", \"draft Reddit replies for prospects\", or \"check Reddit for buying signals\".",
-      "path": "./skills/reddit-icp-monitor"
-    },
-    {
-      "name": "reddit-post-engine",
-      "description": "Writes and optionally posts a Reddit post for any subreddit, following that subreddit's specific culture and rules. Drafts a title, body, and first comment using the 90/10 rule. Uses Composio Reddit MCP for optional direct posting. Use when asked to post on Reddit, draft a Reddit post, share a project on Reddit, write a subreddit post, or launch something on Reddit. Trigger when a user says \"post this on Reddit\", \"write a Reddit post for r/...\", \"help me launch on Reddit\", \"draft something for Reddit\", or \"how do I share this on Reddit without getting banned\".",
-      "path": "./skills/reddit-post-engine"
-    },
-    {
-      "name": "schema-markup-generator",
-      "description": "Skill for schema-markup-generator",
-      "path": "./skills/schema-markup-generator"
-    },
-    {
-      "name": "show-hn-writer",
-      "description": "Skill for show-hn-writer",
-      "path": "./skills/show-hn-writer"
-    },
-    {
-      "name": "stargazer",
-      "description": "A skill for stargazer",
-      "path": "./skills/stargazer"
-    },
-    {
-      "name": "tweet-thread-from-blog",
-      "description": "Converts a blog post URL or article into a Twitter/X thread with a strong hook, one insight per tweet, and a CTA. Optionally posts the full thread to X via Composio using a reply chain. Use when asked to turn a blog post into a tweet thread, repurpose an article for Twitter, create a thread from a blog, write a Twitter thread about a topic, or share a blog post as a thread. Trigger when a user mentions Twitter thread, X thread, tweet thread, or wants to repurpose blog content for X/Twitter.",
-      "path": "./skills/tweet-thread-from-blog"
-    },
-    {
-      "name": "twitter-GTM-find-skill",
-      "description": "A skill for twitter-GTM-find-skill",
-      "path": "./skills/twitter-GTM-find-skill"
-    },
-    {
-      "name": "yc-intent-radar-skill",
-      "description": "A skill for yc-intent-radar-skill",
-      "path": "./skills/yc-intent-radar-skill"
-    }
+  "version": "1.0.1",
+  "description": "A collection of 55 GTM skills for Claude Code",
+  "author": {
+    "name": "Varnan"
+  },
+  "homepage": "https://github.com/Varnan-Tech/opendirectory",
+  "repository": "https://github.com/Varnan-Tech/opendirectory",
+  "license": "MIT",
+  "keywords": [
+    "gtm",
+    "marketing",
+    "growth",
+    "claude-code",
+    "skills",
+    "ai-agents"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "opendirectory-cli-root",
   "private": true,
+  "version": "1.0.1",
   "scripts": {
     "test": "vitest",
     "build:plugin": "tsx scripts/build-claude-plugin.ts",

--- a/scripts/build-claude-plugin.test.ts
+++ b/scripts/build-claude-plugin.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import * as fs from 'fs';
+import * as path from 'path';
+
+// Mirrors Anthropic's Claude Code plugin.json schema.
+// Spec: https://code.claude.com/docs/en/plugins-reference
+// Regression test for: https://github.com/Varnan-Tech/opendirectory/issues/24
+const AuthorSchema = z.object({
+  name: z.string().min(1),
+  email: z.string().email().optional(),
+  url: z.string().url().optional(),
+});
+
+const PathOverride = z.union([z.string(), z.array(z.string())]);
+
+const PluginManifestSchema = z.object({
+  name: z.string().regex(/^[a-z0-9][a-z0-9-]*$/, 'must be kebab-case'),
+  version: z.string().regex(/^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$/, 'must be valid semver'),
+  description: z.string().optional(),
+  author: AuthorSchema.optional(),
+  homepage: z.string().url().optional(),
+  repository: z.union([z.string().url(), z.object({ type: z.string(), url: z.string().url() })]).optional(),
+  license: z.string().optional(),
+  keywords: z.array(z.string()).optional(),
+  commands: PathOverride.optional(),
+  agents: PathOverride.optional(),
+  skills: PathOverride.optional(),
+  hooks: z.union([z.string(), z.record(z.unknown())]).optional(),
+  mcpServers: z.union([z.string(), z.record(z.unknown())]).optional(),
+  lspServers: z.union([z.string(), z.record(z.unknown())]).optional(),
+}).strict(); // strict() rejects unknown keys — matches Anthropic's strict Zod validator
+
+const MarketplacePluginSchema = z.object({
+  name: z.string(),
+  source: z.string(),
+  description: z.string().optional(),
+}).strict();
+
+const MarketplaceManifestSchema = z.object({
+  name: z.string(),
+  description: z.string().optional(),
+  owner: z.object({ name: z.string() }).strict(),
+  plugins: z.array(MarketplacePluginSchema),
+}).strict();
+
+describe('Claude Code plugin manifest (regression test for issue #24)', () => {
+  it('plugin.json validates against the official Anthropic schema', () => {
+    const pluginJsonPath = path.join(process.cwd(), '.claude-plugin', 'plugin.json');
+    const raw = JSON.parse(fs.readFileSync(pluginJsonPath, 'utf-8'));
+    const result = PluginManifestSchema.safeParse(raw);
+    if (!result.success) {
+      throw new Error(`plugin.json failed validation:\n${JSON.stringify(result.error.format(), null, 2)}`);
+    }
+  });
+
+  it('plugin.json author is an object, not a string (issue #24 regression guard)', () => {
+    const raw = JSON.parse(fs.readFileSync(path.join(process.cwd(), '.claude-plugin', 'plugin.json'), 'utf-8'));
+    expect(typeof raw.author).toBe('object');
+    expect(raw.author).not.toBeNull();
+    expect(Array.isArray(raw.author)).toBe(false);
+    expect(raw.author.name).toBeTruthy();
+  });
+
+  it('plugin.json does NOT contain a skills metadata array (issue #24 regression guard)', () => {
+    const raw = JSON.parse(fs.readFileSync(path.join(process.cwd(), '.claude-plugin', 'plugin.json'), 'utf-8'));
+    // The bug was: skills was an array of {name, description, path} objects.
+    // The fix is: skills is omitted entirely OR is a string/string[] of paths.
+    if (raw.skills !== undefined) {
+      const ok = typeof raw.skills === 'string' || (Array.isArray(raw.skills) && raw.skills.every((s: unknown) => typeof s === 'string'));
+      expect(ok, 'skills must be string or string[] per Anthropic schema').toBe(true);
+    }
+  });
+
+  it('marketplace.json validates against the official Anthropic marketplace schema', () => {
+    const marketplacePath = path.join(process.cwd(), '.claude-plugin', 'marketplace.json');
+    const raw = JSON.parse(fs.readFileSync(marketplacePath, 'utf-8'));
+    const result = MarketplaceManifestSchema.safeParse(raw);
+    if (!result.success) {
+      throw new Error(`marketplace.json failed validation:\n${JSON.stringify(result.error.format(), null, 2)}`);
+    }
+  });
+
+  it('plugin name is kebab-case (matches what README documents users typing)', () => {
+    const raw = JSON.parse(fs.readFileSync(path.join(process.cwd(), '.claude-plugin', 'plugin.json'), 'utf-8'));
+    expect(raw.name).toMatch(/^[a-z0-9][a-z0-9-]*$/);
+    expect(raw.name).toBe('opendirectory-gtm-skills');
+  });
+});

--- a/scripts/build-claude-plugin.test.ts
+++ b/scripts/build-claude-plugin.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll } from 'vitest';
 import { z } from 'zod';
 import * as fs from 'fs';
 import * as path from 'path';
+import { execFileSync } from 'child_process';
 
 // Mirrors Anthropic's Claude Code plugin.json schema.
 // Spec: https://code.claude.com/docs/en/plugins-reference
@@ -29,7 +30,7 @@ const PluginManifestSchema = z.object({
   hooks: z.union([z.string(), z.record(z.unknown())]).optional(),
   mcpServers: z.union([z.string(), z.record(z.unknown())]).optional(),
   lspServers: z.union([z.string(), z.record(z.unknown())]).optional(),
-}).strict(); // strict() rejects unknown keys — matches Anthropic's strict Zod validator
+}).strict();
 
 const MarketplacePluginSchema = z.object({
   name: z.string(),
@@ -44,10 +45,27 @@ const MarketplaceManifestSchema = z.object({
   plugins: z.array(MarketplacePluginSchema),
 }).strict();
 
+const REPO_ROOT = path.resolve(__dirname, '..');
+const PLUGIN_JSON_PATH = path.join(REPO_ROOT, '.claude-plugin', 'plugin.json');
+const MARKETPLACE_JSON_PATH = path.join(REPO_ROOT, '.claude-plugin', 'marketplace.json');
+const SKILLS_DIR = path.join(REPO_ROOT, 'skills');
+const BUILD_SCRIPT = path.join(__dirname, 'build-claude-plugin.ts');
+
+function countSkillsOnDisk(): number {
+  if (!fs.existsSync(SKILLS_DIR)) return 0;
+  return fs.readdirSync(SKILLS_DIR).filter(file => {
+    if (file.startsWith('.')) return false;
+    return fs.statSync(path.join(SKILLS_DIR, file)).isDirectory();
+  }).length;
+}
+
 describe('Claude Code plugin manifest (regression test for issue #24)', () => {
+  beforeAll(() => {
+    execFileSync('npx', ['tsx', BUILD_SCRIPT], { cwd: REPO_ROOT, stdio: 'pipe', shell: process.platform === 'win32' });
+  });
+
   it('plugin.json validates against the official Anthropic schema', () => {
-    const pluginJsonPath = path.join(process.cwd(), '.claude-plugin', 'plugin.json');
-    const raw = JSON.parse(fs.readFileSync(pluginJsonPath, 'utf-8'));
+    const raw = JSON.parse(fs.readFileSync(PLUGIN_JSON_PATH, 'utf-8'));
     const result = PluginManifestSchema.safeParse(raw);
     if (!result.success) {
       throw new Error(`plugin.json failed validation:\n${JSON.stringify(result.error.format(), null, 2)}`);
@@ -55,7 +73,7 @@ describe('Claude Code plugin manifest (regression test for issue #24)', () => {
   });
 
   it('plugin.json author is an object, not a string (issue #24 regression guard)', () => {
-    const raw = JSON.parse(fs.readFileSync(path.join(process.cwd(), '.claude-plugin', 'plugin.json'), 'utf-8'));
+    const raw = JSON.parse(fs.readFileSync(PLUGIN_JSON_PATH, 'utf-8'));
     expect(typeof raw.author).toBe('object');
     expect(raw.author).not.toBeNull();
     expect(Array.isArray(raw.author)).toBe(false);
@@ -63,9 +81,7 @@ describe('Claude Code plugin manifest (regression test for issue #24)', () => {
   });
 
   it('plugin.json does NOT contain a skills metadata array (issue #24 regression guard)', () => {
-    const raw = JSON.parse(fs.readFileSync(path.join(process.cwd(), '.claude-plugin', 'plugin.json'), 'utf-8'));
-    // The bug was: skills was an array of {name, description, path} objects.
-    // The fix is: skills is omitted entirely OR is a string/string[] of paths.
+    const raw = JSON.parse(fs.readFileSync(PLUGIN_JSON_PATH, 'utf-8'));
     if (raw.skills !== undefined) {
       const ok = typeof raw.skills === 'string' || (Array.isArray(raw.skills) && raw.skills.every((s: unknown) => typeof s === 'string'));
       expect(ok, 'skills must be string or string[] per Anthropic schema').toBe(true);
@@ -73,8 +89,7 @@ describe('Claude Code plugin manifest (regression test for issue #24)', () => {
   });
 
   it('marketplace.json validates against the official Anthropic marketplace schema', () => {
-    const marketplacePath = path.join(process.cwd(), '.claude-plugin', 'marketplace.json');
-    const raw = JSON.parse(fs.readFileSync(marketplacePath, 'utf-8'));
+    const raw = JSON.parse(fs.readFileSync(MARKETPLACE_JSON_PATH, 'utf-8'));
     const result = MarketplaceManifestSchema.safeParse(raw);
     if (!result.success) {
       throw new Error(`marketplace.json failed validation:\n${JSON.stringify(result.error.format(), null, 2)}`);
@@ -82,8 +97,21 @@ describe('Claude Code plugin manifest (regression test for issue #24)', () => {
   });
 
   it('plugin name is kebab-case (matches what README documents users typing)', () => {
-    const raw = JSON.parse(fs.readFileSync(path.join(process.cwd(), '.claude-plugin', 'plugin.json'), 'utf-8'));
+    const raw = JSON.parse(fs.readFileSync(PLUGIN_JSON_PATH, 'utf-8'));
     expect(raw.name).toMatch(/^[a-z0-9][a-z0-9-]*$/);
     expect(raw.name).toBe('opendirectory-gtm-skills');
+  });
+
+  it('marketplace description reflects the actual on-disk skill count (catches stale committed JSON)', () => {
+    const raw = JSON.parse(fs.readFileSync(MARKETPLACE_JSON_PATH, 'utf-8'));
+    const expectedCount = countSkillsOnDisk();
+    const description: string = raw.plugins?.[0]?.description ?? '';
+    expect(description).toMatch(new RegExp(`\\b${expectedCount}\\b`));
+  });
+
+  it('plugin.json description reflects the actual on-disk skill count', () => {
+    const raw = JSON.parse(fs.readFileSync(PLUGIN_JSON_PATH, 'utf-8'));
+    const expectedCount = countSkillsOnDisk();
+    expect(raw.description).toMatch(new RegExp(`\\b${expectedCount}\\b`));
   });
 });

--- a/scripts/build-claude-plugin.ts
+++ b/scripts/build-claude-plugin.ts
@@ -10,7 +10,7 @@ const PKG_JSON_PATH = path.join(ROOT_DIR, 'package.json');
 
 function readPluginVersion(): string {
   const pkg = JSON.parse(fs.readFileSync(PKG_JSON_PATH, 'utf-8'));
-  if (typeof pkg.version !== 'string' || !/^\d+\.\d+\.\d+/.test(pkg.version)) {
+  if (typeof pkg.version !== 'string' || !/^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$/.test(pkg.version)) {
     throw new Error(`Root package.json is missing a valid semver "version" field; got: ${JSON.stringify(pkg.version)}`);
   }
   return pkg.version;

--- a/scripts/build-claude-plugin.ts
+++ b/scripts/build-claude-plugin.ts
@@ -1,63 +1,66 @@
 import fs from 'fs';
 import path from 'path';
-import matter from 'gray-matter';
 
-const SKILLS_DIR = path.join(process.cwd(), 'skills');
-const PLUGIN_DIR = path.join(process.cwd(), '.claude-plugin');
+const ROOT_DIR = path.resolve(__dirname, '..');
+const SKILLS_DIR = path.join(ROOT_DIR, 'skills');
+const PLUGIN_DIR = path.join(ROOT_DIR, '.claude-plugin');
 const PLUGIN_JSON_PATH = path.join(PLUGIN_DIR, 'plugin.json');
-const MARKETPLACE_JSON_PATH = path.join(process.cwd(), 'marketplace.json');
+const MARKETPLACE_JSON_PATH = path.join(PLUGIN_DIR, 'marketplace.json');
+const PKG_JSON_PATH = path.join(ROOT_DIR, 'package.json');
+
+function readPluginVersion(): string {
+  const pkg = JSON.parse(fs.readFileSync(PKG_JSON_PATH, 'utf-8'));
+  if (typeof pkg.version !== 'string' || !/^\d+\.\d+\.\d+/.test(pkg.version)) {
+    throw new Error(`Root package.json is missing a valid semver "version" field; got: ${JSON.stringify(pkg.version)}`);
+  }
+  return pkg.version;
+}
+
+function countSkills(): number {
+  if (!fs.existsSync(SKILLS_DIR)) return 0;
+  return fs.readdirSync(SKILLS_DIR).filter(file => {
+    if (file.startsWith('.')) return false;
+    return fs.statSync(path.join(SKILLS_DIR, file)).isDirectory();
+  }).length;
+}
 
 function buildPlugin() {
   if (!fs.existsSync(PLUGIN_DIR)) {
     fs.mkdirSync(PLUGIN_DIR, { recursive: true });
   }
 
-  const skills: any[] = [];
-
-  if (fs.existsSync(SKILLS_DIR)) {
-    const skillDirs = fs.readdirSync(SKILLS_DIR).filter(file => {
-      return fs.statSync(path.join(SKILLS_DIR, file)).isDirectory();
-    });
-
-    for (const dir of skillDirs) {
-      const skillMdPath = path.join(SKILLS_DIR, dir, 'SKILL.md');
-      if (fs.existsSync(skillMdPath)) {
-        const content = fs.readFileSync(skillMdPath, 'utf-8');
-        const parsed = matter(content);
-        
-        skills.push({
-          name: parsed.data.name || dir,
-          description: parsed.data.description || `Skill for ${dir}`,
-          path: `./skills/${dir}`
-        });
-      }
-    }
-  }
+  const skillCount = countSkills();
+  const version = readPluginVersion();
 
   const pluginData = {
-    name: "OpenDirectory GTM Skills",
-    author: "Varnan",
-    description: "A collection of GTM skills for Claude Code",
-    version: "1.0.0",
-    skills: skills
+    name: "opendirectory-gtm-skills",
+    version,
+    description: `A collection of ${skillCount} GTM skills for Claude Code`,
+    author: { name: "Varnan" },
+    homepage: "https://github.com/Varnan-Tech/opendirectory",
+    repository: "https://github.com/Varnan-Tech/opendirectory",
+    license: "MIT",
+    keywords: ["gtm", "marketing", "growth", "claude-code", "skills", "ai-agents"]
   };
 
   fs.writeFileSync(PLUGIN_JSON_PATH, JSON.stringify(pluginData, null, 2));
-  console.log(`Generated ${PLUGIN_JSON_PATH} with ${skills.length} skills.`);
+  console.log(`Generated ${PLUGIN_JSON_PATH} (v${version}, ${skillCount} skills).`);
 
   const marketplaceData = {
-    name: "OpenDirectory Marketplace",
+    name: "opendirectory-marketplace",
     description: "Official marketplace for OpenDirectory skills",
+    owner: { name: "Varnan" },
     plugins: [
       {
-        name: "OpenDirectory GTM Skills",
-        path: "./.claude-plugin"
+        name: "opendirectory-gtm-skills",
+        source: "./",
+        description: `${skillCount} GTM and Marketing Skills`
       }
     ]
   };
 
   fs.writeFileSync(MARKETPLACE_JSON_PATH, JSON.stringify(marketplaceData, null, 2));
-  console.log(`Generated ${MARKETPLACE_JSON_PATH}.`);
+  console.log(`Generated ${MARKETPLACE_JSON_PATH} (v${version}, ${skillCount} skills).`);
 }
 
 buildPlugin();


### PR DESCRIPTION
Fixes strict-Zod validation errors blocking `/plugin install` (Issue #24).

### Changes

- **`author`**: string `"Varnan"` -> object `{"name": "Varnan"}`. Schema requires an object.
- **`skills`**: removed the 28-entry metadata array. Claude Code auto-discovers skills from `./skills/*/SKILL.md`. Schema expects path overrides, not metadata objects.
- **`name`**: `"OpenDirectory GTM Skills"` -> `"opendirectory-gtm-skills"` (kebab-case as required).
- **Version**: hardcoded -> reads dynamically from root `package.json`. Next `pnpm build:plugin` picks up any version bump automatically.
- **Skill count**: hardcoded `"28+"` -> computed dynamically from `skills/` directory (currently 55). No more manual updates when adding skills.
- **`marketplace.json`**: now written inside `.claude-plugin/` with correct schema (`owner`, `plugins[].source` instead of old `plugins[].path`).
- **Path safety**: switched from `process.cwd()` to `path.resolve(__dirname, '..')`. Works regardless of which directory the script is run from.
- **Regression guard**: new Vitest test (`build-claude-plugin.test.ts`) with 5 assertions mirroring Anthropic's plug-in schema. Catches future drift.

### Verification

- `npx vitest run` -> 15/15 tests pass
- `pnpm exec tsx scripts/validate-pr.ts` -> all 55 skills valid
- Manual `/plugin install` tested locally -> works, all skills discoverable

Closes #24.
