### PR TITLE
Add skills.sh install support

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,23 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install <skill-name> --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory
+```
+
+Installs all skills and auto-detects your coding agent (Claude Code, Codex, Gemini CLI, OpenCode, and more). To install a single skill:
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill <skill-name>
+```
+
+Browse OpenDirectory on skills.sh: [skills.sh/Varnan-Tech/opendirectory](https://www.skills.sh/Varnan-Tech/opendirectory)
+
+> Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
+
+### Option C: Claude Desktop App
 
 https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c
 
@@ -219,7 +235,7 @@ https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c
 
 For some skills, the `SKILL.md` file sits inside a subfolder. Always upload the specific folder containing `SKILL.md`.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -232,7 +248,7 @@ Run these commands inside Claude Code:
 ```
 
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4
 
@@ -244,22 +260,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory
-```
-
-Installs all skills and auto-detects your coding agent (Claude Code, Codex, Gemini CLI, OpenCode, and more). To install a single skill:
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill <skill-name>
-```
-
-Browse OpenDirectory on skills.sh: [skills.sh/Varnan-Tech/opendirectory](https://www.skills.sh/Varnan-Tech/opendirectory)
-
-> Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 [![Contributors](https://img.shields.io/github/contributors/Varnan-Tech/opendirectory?style=flat-square&color=orange)](https://github.com/Varnan-Tech/opendirectory/graphs/contributors)
 [![Agents](https://img.shields.io/badge/agents-8-blueviolet.svg?style=flat-square)](#quick-start)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](CONTRIBUTING.md)
+[![skills.sh](https://img.shields.io/badge/skills.sh-listed-brightgreen.svg?style=flat-square)](https://www.skills.sh/Varnan-Tech/opendirectory)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=flat-square)](https://opensource.org/licenses/MIT)
 
 </div>
@@ -243,6 +244,22 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory
+```
+
+Installs all skills and auto-detects your coding agent (Claude Code, Codex, Gemini CLI, OpenCode, and more). To install a single skill:
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill <skill-name>
+```
+
+Browse OpenDirectory on skills.sh: [skills.sh/Varnan-Tech/opendirectory](https://www.skills.sh/Varnan-Tech/opendirectory)
+
+> Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ---
 

--- a/scripts/update_skill_readmes.py
+++ b/scripts/update_skill_readmes.py
@@ -136,7 +136,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install {skill_name} --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill {skill_name}
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -155,7 +163,7 @@ npx "@opendirectory.dev/skills" install {skill_name} --target claude
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -164,7 +172,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -178,14 +186,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill {skill_name}
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 {END_MARKER}
 """
 

--- a/scripts/update_skill_readmes.py
+++ b/scripts/update_skill_readmes.py
@@ -178,6 +178,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill {skill_name}
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 {END_MARKER}
 """
 

--- a/scripts/update_skill_readmes.py
+++ b/scripts/update_skill_readmes.py
@@ -142,7 +142,7 @@ npx "@opendirectory.dev/skills" install {skill_name} --target claude
 npx skills add Varnan-Tech/opendirectory --skill {skill_name}
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/app-store-review-arbitrage/README.md
+++ b/skills/app-store-review-arbitrage/README.md
@@ -17,7 +17,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install app-store-review-arbitrage --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill app-store-review-arbitrage
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -36,7 +44,7 @@ npx "@opendirectory.dev/skills" install app-store-review-arbitrage --target clau
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -45,7 +53,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -59,14 +67,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill app-store-review-arbitrage
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/app-store-review-arbitrage/README.md
+++ b/skills/app-store-review-arbitrage/README.md
@@ -59,6 +59,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill app-store-review-arbitrage
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/app-store-review-arbitrage/README.md
+++ b/skills/app-store-review-arbitrage/README.md
@@ -23,7 +23,7 @@ npx "@opendirectory.dev/skills" install app-store-review-arbitrage --target clau
 npx skills add Varnan-Tech/opendirectory --skill app-store-review-arbitrage
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/blog-cover-image-cli/README.md
+++ b/skills/blog-cover-image-cli/README.md
@@ -67,6 +67,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill blog-cover-image-cli
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/blog-cover-image-cli/README.md
+++ b/skills/blog-cover-image-cli/README.md
@@ -25,7 +25,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install blog-cover-image-cli --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill blog-cover-image-cli
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -44,7 +52,7 @@ npx "@opendirectory.dev/skills" install blog-cover-image-cli --target claude
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -53,7 +61,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -67,14 +75,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill blog-cover-image-cli
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/blog-cover-image-cli/README.md
+++ b/skills/blog-cover-image-cli/README.md
@@ -31,7 +31,7 @@ npx "@opendirectory.dev/skills" install blog-cover-image-cli --target claude
 npx skills add Varnan-Tech/opendirectory --skill blog-cover-image-cli
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/brand-alchemy/README.md
+++ b/skills/brand-alchemy/README.md
@@ -57,6 +57,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill brand-alchemy
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/brand-alchemy/README.md
+++ b/skills/brand-alchemy/README.md
@@ -21,7 +21,7 @@ npx "@opendirectory.dev/skills" install brand-alchemy --target claude
 npx skills add Varnan-Tech/opendirectory --skill brand-alchemy
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/brand-alchemy/README.md
+++ b/skills/brand-alchemy/README.md
@@ -15,7 +15,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install brand-alchemy --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill brand-alchemy
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -34,7 +42,7 @@ npx "@opendirectory.dev/skills" install brand-alchemy --target claude
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -43,7 +51,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -57,14 +65,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill brand-alchemy
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/claude-md-generator/README.md
+++ b/skills/claude-md-generator/README.md
@@ -22,7 +22,7 @@ npx "@opendirectory.dev/skills" install claude-md-generator --target claude
 npx skills add Varnan-Tech/opendirectory --skill claude-md-generator
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/claude-md-generator/README.md
+++ b/skills/claude-md-generator/README.md
@@ -58,6 +58,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill claude-md-generator
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/claude-md-generator/README.md
+++ b/skills/claude-md-generator/README.md
@@ -16,7 +16,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install claude-md-generator --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill claude-md-generator
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -35,7 +43,7 @@ npx "@opendirectory.dev/skills" install claude-md-generator --target claude
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -44,7 +52,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -58,14 +66,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill claude-md-generator
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/cold-email-verifier/README.md
+++ b/skills/cold-email-verifier/README.md
@@ -23,7 +23,7 @@ npx "@opendirectory.dev/skills" install cold-email-verifier --target claude
 npx skills add Varnan-Tech/opendirectory --skill cold-email-verifier
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/cold-email-verifier/README.md
+++ b/skills/cold-email-verifier/README.md
@@ -17,7 +17,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install cold-email-verifier --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill cold-email-verifier
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -36,7 +44,7 @@ npx "@opendirectory.dev/skills" install cold-email-verifier --target claude
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -45,7 +53,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -59,14 +67,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill cold-email-verifier
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/cold-email-verifier/README.md
+++ b/skills/cold-email-verifier/README.md
@@ -59,6 +59,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill cold-email-verifier
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/company-radar/README.md
+++ b/skills/company-radar/README.md
@@ -57,6 +57,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill company-radar
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/company-radar/README.md
+++ b/skills/company-radar/README.md
@@ -15,7 +15,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install company-radar --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill company-radar
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -34,7 +42,7 @@ npx "@opendirectory.dev/skills" install company-radar --target claude
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -43,7 +51,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -57,14 +65,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill company-radar
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/company-radar/README.md
+++ b/skills/company-radar/README.md
@@ -21,7 +21,7 @@ npx "@opendirectory.dev/skills" install company-radar --target claude
 npx skills add Varnan-Tech/opendirectory --skill company-radar
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/competitor-pr-finder/README.md
+++ b/skills/competitor-pr-finder/README.md
@@ -19,7 +19,7 @@ npx "@opendirectory.dev/skills" install competitor-pr-finder --target claude
 npx skills add Varnan-Tech/opendirectory --skill competitor-pr-finder
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/competitor-pr-finder/README.md
+++ b/skills/competitor-pr-finder/README.md
@@ -55,6 +55,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill competitor-pr-finder
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/competitor-pr-finder/README.md
+++ b/skills/competitor-pr-finder/README.md
@@ -13,7 +13,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install competitor-pr-finder --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill competitor-pr-finder
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -32,7 +40,7 @@ npx "@opendirectory.dev/skills" install competitor-pr-finder --target claude
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -41,7 +49,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -55,14 +63,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill competitor-pr-finder
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/cook-the-blog/README.md
+++ b/skills/cook-the-blog/README.md
@@ -15,7 +15,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install cook-the-blog --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill cook-the-blog
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -34,7 +42,7 @@ npx "@opendirectory.dev/skills" install cook-the-blog --target claude
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -43,7 +51,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -57,14 +65,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill cook-the-blog
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/cook-the-blog/README.md
+++ b/skills/cook-the-blog/README.md
@@ -57,6 +57,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill cook-the-blog
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/cook-the-blog/README.md
+++ b/skills/cook-the-blog/README.md
@@ -21,7 +21,7 @@ npx "@opendirectory.dev/skills" install cook-the-blog --target claude
 npx skills add Varnan-Tech/opendirectory --skill cook-the-blog
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/dependency-update-bot/README.md
+++ b/skills/dependency-update-bot/README.md
@@ -16,7 +16,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install dependency-update-bot --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill dependency-update-bot
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -35,7 +43,7 @@ npx "@opendirectory.dev/skills" install dependency-update-bot --target claude
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -44,7 +52,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -58,14 +66,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill dependency-update-bot
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/dependency-update-bot/README.md
+++ b/skills/dependency-update-bot/README.md
@@ -58,6 +58,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill dependency-update-bot
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/dependency-update-bot/README.md
+++ b/skills/dependency-update-bot/README.md
@@ -22,7 +22,7 @@ npx "@opendirectory.dev/skills" install dependency-update-bot --target claude
 npx skills add Varnan-Tech/opendirectory --skill dependency-update-bot
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/docs-from-code/README.md
+++ b/skills/docs-from-code/README.md
@@ -21,7 +21,7 @@ npx "@opendirectory.dev/skills" install docs-from-code --target claude
 npx skills add Varnan-Tech/opendirectory --skill docs-from-code
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/docs-from-code/README.md
+++ b/skills/docs-from-code/README.md
@@ -15,7 +15,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install docs-from-code --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill docs-from-code
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -34,7 +42,7 @@ npx "@opendirectory.dev/skills" install docs-from-code --target claude
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -43,7 +51,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -57,14 +65,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill docs-from-code
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/docs-from-code/README.md
+++ b/skills/docs-from-code/README.md
@@ -57,6 +57,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill docs-from-code
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/domain-expired-opportunity-finder/README.md
+++ b/skills/domain-expired-opportunity-finder/README.md
@@ -14,7 +14,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install domain-expired-opportunity-finder --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill domain-expired-opportunity-finder
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -33,7 +41,7 @@ npx "@opendirectory.dev/skills" install domain-expired-opportunity-finder --targ
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -42,7 +50,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -56,14 +64,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill domain-expired-opportunity-finder
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/domain-expired-opportunity-finder/README.md
+++ b/skills/domain-expired-opportunity-finder/README.md
@@ -56,6 +56,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill domain-expired-opportunity-finder
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/domain-expired-opportunity-finder/README.md
+++ b/skills/domain-expired-opportunity-finder/README.md
@@ -20,7 +20,7 @@ npx "@opendirectory.dev/skills" install domain-expired-opportunity-finder --targ
 npx skills add Varnan-Tech/opendirectory --skill domain-expired-opportunity-finder
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/dx-roaster/README.md
+++ b/skills/dx-roaster/README.md
@@ -61,6 +61,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill dx-roaster
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/dx-roaster/README.md
+++ b/skills/dx-roaster/README.md
@@ -25,7 +25,7 @@ npx "@opendirectory.dev/skills" install dx-roaster --target claude
 npx skills add Varnan-Tech/opendirectory --skill dx-roaster
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/dx-roaster/README.md
+++ b/skills/dx-roaster/README.md
@@ -19,7 +19,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install dx-roaster --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill dx-roaster
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -38,7 +46,7 @@ npx "@opendirectory.dev/skills" install dx-roaster --target claude
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -47,7 +55,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -61,14 +69,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill dx-roaster
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/email-newsletter/README.md
+++ b/skills/email-newsletter/README.md
@@ -13,7 +13,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install email-newsletter --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill email-newsletter
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -32,7 +40,7 @@ npx "@opendirectory.dev/skills" install email-newsletter --target claude
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -41,7 +49,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -55,14 +63,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill email-newsletter
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/email-newsletter/README.md
+++ b/skills/email-newsletter/README.md
@@ -55,6 +55,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill email-newsletter
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/email-newsletter/README.md
+++ b/skills/email-newsletter/README.md
@@ -19,7 +19,7 @@ npx "@opendirectory.dev/skills" install email-newsletter --target claude
 npx skills add Varnan-Tech/opendirectory --skill email-newsletter
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/explain-this-pr/README.md
+++ b/skills/explain-this-pr/README.md
@@ -16,7 +16,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install explain-this-pr --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill explain-this-pr
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -35,7 +43,7 @@ npx "@opendirectory.dev/skills" install explain-this-pr --target claude
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -44,7 +52,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -58,14 +66,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill explain-this-pr
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/explain-this-pr/README.md
+++ b/skills/explain-this-pr/README.md
@@ -22,7 +22,7 @@ npx "@opendirectory.dev/skills" install explain-this-pr --target claude
 npx skills add Varnan-Tech/opendirectory --skill explain-this-pr
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/explain-this-pr/README.md
+++ b/skills/explain-this-pr/README.md
@@ -58,6 +58,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill explain-this-pr
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/geo-gap-fixer/README.md
+++ b/skills/geo-gap-fixer/README.md
@@ -2,13 +2,6 @@
 
 **Audit how often LLMs recommend your brand vs. competitors — then get a concrete action plan to fix the gaps.**
 
-## Why this skill exists
-In 2026, buyers discover tools by asking ChatGPT, Claude, Gemini, and Perplexity *"what's the best X for Y?"* — not by Googling. If LLMs consistently recommend a competitor instead of you, your traditional SEO rank is irrelevant.
-
-**geo-gap-fixer** is a free, open-source agent skill for GTM Intelligence that audits your Generative Engine Optimization (GEO) share-of-voice. It probes the LLMs, analyzes who gets recommended, and outputs a prioritized content backlog to fix the gaps.
-
-> One skill run replaces a $200/month AI-monitoring SaaS subscription.
-
 <!-- OPENDIRECTORY_INSTALL_START -->
 ## Install
 
@@ -62,7 +55,23 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill geo-gap-fixer
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
+
+
+## Why this skill exists
+In 2026, buyers discover tools by asking ChatGPT, Claude, Gemini, and Perplexity *"what's the best X for Y?"* — not by Googling. If LLMs consistently recommend a competitor instead of you, your traditional SEO rank is irrelevant.
+
+**geo-gap-fixer** is a free, open-source agent skill for GTM Intelligence that audits your Generative Engine Optimization (GEO) share-of-voice. It probes the LLMs, analyzes who gets recommended, and outputs a prioritized content backlog to fix the gaps.
+
+> One skill run replaces a $200/month AI-monitoring SaaS subscription.
 
 ---
 

--- a/skills/geo-gap-fixer/README.md
+++ b/skills/geo-gap-fixer/README.md
@@ -13,7 +13,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install geo-gap-fixer --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill geo-gap-fixer
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -32,7 +40,7 @@ npx "@opendirectory.dev/skills" install geo-gap-fixer --target claude
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -41,7 +49,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -55,14 +63,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill geo-gap-fixer
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/geo-gap-fixer/README.md
+++ b/skills/geo-gap-fixer/README.md
@@ -19,7 +19,7 @@ npx "@opendirectory.dev/skills" install geo-gap-fixer --target claude
 npx skills add Varnan-Tech/opendirectory --skill geo-gap-fixer
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/gh-issue-to-demand-signal/README.md
+++ b/skills/gh-issue-to-demand-signal/README.md
@@ -19,7 +19,7 @@ npx "@opendirectory.dev/skills" install gh-issue-to-demand-signal --target claud
 npx skills add Varnan-Tech/opendirectory --skill gh-issue-to-demand-signal
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/gh-issue-to-demand-signal/README.md
+++ b/skills/gh-issue-to-demand-signal/README.md
@@ -55,6 +55,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill gh-issue-to-demand-signal
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/gh-issue-to-demand-signal/README.md
+++ b/skills/gh-issue-to-demand-signal/README.md
@@ -13,7 +13,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install gh-issue-to-demand-signal --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill gh-issue-to-demand-signal
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -32,7 +40,7 @@ npx "@opendirectory.dev/skills" install gh-issue-to-demand-signal --target claud
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -41,7 +49,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -55,14 +63,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill gh-issue-to-demand-signal
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/github-discussion-to-devrel-content/README.md
+++ b/skills/github-discussion-to-devrel-content/README.md
@@ -23,7 +23,7 @@ npx "@opendirectory.dev/skills" install github-discussion-to-devrel-content --ta
 npx skills add Varnan-Tech/opendirectory --skill github-discussion-to-devrel-content
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/github-discussion-to-devrel-content/README.md
+++ b/skills/github-discussion-to-devrel-content/README.md
@@ -17,7 +17,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install github-discussion-to-devrel-content --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill github-discussion-to-devrel-content
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -36,7 +44,7 @@ npx "@opendirectory.dev/skills" install github-discussion-to-devrel-content --ta
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -45,7 +53,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -59,14 +67,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill github-discussion-to-devrel-content
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/github-discussion-to-devrel-content/README.md
+++ b/skills/github-discussion-to-devrel-content/README.md
@@ -59,6 +59,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill github-discussion-to-devrel-content
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/google-trends-api-skills/README.md
+++ b/skills/google-trends-api-skills/README.md
@@ -21,7 +21,7 @@ npx "@opendirectory.dev/skills" install google-trends-api-skills --target claude
 npx skills add Varnan-Tech/opendirectory --skill google-trends-api-skills
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/google-trends-api-skills/README.md
+++ b/skills/google-trends-api-skills/README.md
@@ -15,7 +15,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install google-trends-api-skills --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill google-trends-api-skills
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -34,7 +42,7 @@ npx "@opendirectory.dev/skills" install google-trends-api-skills --target claude
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -43,7 +51,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -57,14 +65,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill google-trends-api-skills
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/google-trends-api-skills/README.md
+++ b/skills/google-trends-api-skills/README.md
@@ -57,6 +57,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill google-trends-api-skills
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/graphic-case-study/README.md
+++ b/skills/graphic-case-study/README.md
@@ -55,6 +55,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill graphic-case-study
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/graphic-case-study/README.md
+++ b/skills/graphic-case-study/README.md
@@ -13,7 +13,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install graphic-case-study --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill graphic-case-study
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -32,7 +40,7 @@ npx "@opendirectory.dev/skills" install graphic-case-study --target claude
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -41,7 +49,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -55,14 +63,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill graphic-case-study
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/graphic-case-study/README.md
+++ b/skills/graphic-case-study/README.md
@@ -19,7 +19,7 @@ npx "@opendirectory.dev/skills" install graphic-case-study --target claude
 npx skills add Varnan-Tech/opendirectory --skill graphic-case-study
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/graphic-chart/README.md
+++ b/skills/graphic-chart/README.md
@@ -19,7 +19,7 @@ npx "@opendirectory.dev/skills" install graphic-chart --target claude
 npx skills add Varnan-Tech/opendirectory --skill graphic-chart
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/graphic-chart/README.md
+++ b/skills/graphic-chart/README.md
@@ -55,6 +55,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill graphic-chart
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/graphic-chart/README.md
+++ b/skills/graphic-chart/README.md
@@ -13,7 +13,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install graphic-chart --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill graphic-chart
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -32,7 +40,7 @@ npx "@opendirectory.dev/skills" install graphic-chart --target claude
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -41,7 +49,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -55,14 +63,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill graphic-chart
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/graphic-ebook/README.md
+++ b/skills/graphic-ebook/README.md
@@ -19,7 +19,7 @@ npx "@opendirectory.dev/skills" install graphic-ebook --target claude
 npx skills add Varnan-Tech/opendirectory --skill graphic-ebook
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/graphic-ebook/README.md
+++ b/skills/graphic-ebook/README.md
@@ -55,6 +55,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill graphic-ebook
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/graphic-ebook/README.md
+++ b/skills/graphic-ebook/README.md
@@ -13,7 +13,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install graphic-ebook --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill graphic-ebook
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -32,7 +40,7 @@ npx "@opendirectory.dev/skills" install graphic-ebook --target claude
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -41,7 +49,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -55,14 +63,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill graphic-ebook
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/graphic-gif/README.md
+++ b/skills/graphic-gif/README.md
@@ -55,6 +55,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill graphic-gif
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/graphic-gif/README.md
+++ b/skills/graphic-gif/README.md
@@ -19,7 +19,7 @@ npx "@opendirectory.dev/skills" install graphic-gif --target claude
 npx skills add Varnan-Tech/opendirectory --skill graphic-gif
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/graphic-gif/README.md
+++ b/skills/graphic-gif/README.md
@@ -13,7 +13,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install graphic-gif --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill graphic-gif
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -32,7 +40,7 @@ npx "@opendirectory.dev/skills" install graphic-gif --target claude
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -41,7 +49,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -55,14 +63,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill graphic-gif
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/graphic-slide-deck/README.md
+++ b/skills/graphic-slide-deck/README.md
@@ -19,7 +19,7 @@ npx "@opendirectory.dev/skills" install graphic-slide-deck --target claude
 npx skills add Varnan-Tech/opendirectory --skill graphic-slide-deck
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/graphic-slide-deck/README.md
+++ b/skills/graphic-slide-deck/README.md
@@ -13,7 +13,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install graphic-slide-deck --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill graphic-slide-deck
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -32,7 +40,7 @@ npx "@opendirectory.dev/skills" install graphic-slide-deck --target claude
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -41,7 +49,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -55,14 +63,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill graphic-slide-deck
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/graphic-slide-deck/README.md
+++ b/skills/graphic-slide-deck/README.md
@@ -55,6 +55,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill graphic-slide-deck
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/hackernews-intel/README.md
+++ b/skills/hackernews-intel/README.md
@@ -16,7 +16,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install hackernews-intel --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill hackernews-intel
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -35,7 +43,7 @@ npx "@opendirectory.dev/skills" install hackernews-intel --target claude
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -44,7 +52,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -58,14 +66,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill hackernews-intel
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/hackernews-intel/README.md
+++ b/skills/hackernews-intel/README.md
@@ -58,6 +58,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill hackernews-intel
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/hackernews-intel/README.md
+++ b/skills/hackernews-intel/README.md
@@ -22,7 +22,7 @@ npx "@opendirectory.dev/skills" install hackernews-intel --target claude
 npx skills add Varnan-Tech/opendirectory --skill hackernews-intel
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/human-tone/README.md
+++ b/skills/human-tone/README.md
@@ -23,7 +23,7 @@ npx "@opendirectory.dev/skills" install human-tone --target claude
 npx skills add Varnan-Tech/opendirectory --skill human-tone
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/human-tone/README.md
+++ b/skills/human-tone/README.md
@@ -59,6 +59,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill human-tone
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/human-tone/README.md
+++ b/skills/human-tone/README.md
@@ -17,7 +17,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install human-tone --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill human-tone
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -36,7 +44,7 @@ npx "@opendirectory.dev/skills" install human-tone --target claude
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -45,7 +53,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -59,14 +67,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill human-tone
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/hyperframes-product-launch-video/README.md
+++ b/skills/hyperframes-product-launch-video/README.md
@@ -13,7 +13,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install hyperframes-product-launch-video --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill hyperframes-product-launch-video
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -32,7 +40,7 @@ npx "@opendirectory.dev/skills" install hyperframes-product-launch-video --targe
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -41,7 +49,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -55,14 +63,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill hyperframes-product-launch-video
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/hyperframes-product-launch-video/README.md
+++ b/skills/hyperframes-product-launch-video/README.md
@@ -55,6 +55,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill hyperframes-product-launch-video
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/hyperframes-product-launch-video/README.md
+++ b/skills/hyperframes-product-launch-video/README.md
@@ -19,7 +19,7 @@ npx "@opendirectory.dev/skills" install hyperframes-product-launch-video --targe
 npx skills add Varnan-Tech/opendirectory --skill hyperframes-product-launch-video
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/kill-the-standup/README.md
+++ b/skills/kill-the-standup/README.md
@@ -22,7 +22,7 @@ npx "@opendirectory.dev/skills" install kill-the-standup --target claude
 npx skills add Varnan-Tech/opendirectory --skill kill-the-standup
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/kill-the-standup/README.md
+++ b/skills/kill-the-standup/README.md
@@ -16,7 +16,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install kill-the-standup --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill kill-the-standup
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -35,7 +43,7 @@ npx "@opendirectory.dev/skills" install kill-the-standup --target claude
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -44,7 +52,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -58,14 +66,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill kill-the-standup
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/kill-the-standup/README.md
+++ b/skills/kill-the-standup/README.md
@@ -58,6 +58,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill kill-the-standup
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/linkedin-job-post-to-buyer-pain-map/README.md
+++ b/skills/linkedin-job-post-to-buyer-pain-map/README.md
@@ -15,7 +15,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install linkedin-job-post-to-buyer-pain-map --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill linkedin-job-post-to-buyer-pain-map
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -34,7 +42,7 @@ npx "@opendirectory.dev/skills" install linkedin-job-post-to-buyer-pain-map --ta
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -43,7 +51,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -57,14 +65,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill linkedin-job-post-to-buyer-pain-map
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/linkedin-job-post-to-buyer-pain-map/README.md
+++ b/skills/linkedin-job-post-to-buyer-pain-map/README.md
@@ -21,7 +21,7 @@ npx "@opendirectory.dev/skills" install linkedin-job-post-to-buyer-pain-map --ta
 npx skills add Varnan-Tech/opendirectory --skill linkedin-job-post-to-buyer-pain-map
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/linkedin-job-post-to-buyer-pain-map/README.md
+++ b/skills/linkedin-job-post-to-buyer-pain-map/README.md
@@ -57,6 +57,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill linkedin-job-post-to-buyer-pain-map
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/linkedin-post-generator/README.md
+++ b/skills/linkedin-post-generator/README.md
@@ -15,7 +15,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install linkedin-post-generator --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill linkedin-post-generator
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -34,7 +42,7 @@ npx "@opendirectory.dev/skills" install linkedin-post-generator --target claude
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -43,7 +51,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -57,14 +65,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill linkedin-post-generator
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/linkedin-post-generator/README.md
+++ b/skills/linkedin-post-generator/README.md
@@ -57,6 +57,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill linkedin-post-generator
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/linkedin-post-generator/README.md
+++ b/skills/linkedin-post-generator/README.md
@@ -21,7 +21,7 @@ npx "@opendirectory.dev/skills" install linkedin-post-generator --target claude
 npx skills add Varnan-Tech/opendirectory --skill linkedin-post-generator
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/llms-txt-generator/README.md
+++ b/skills/llms-txt-generator/README.md
@@ -15,7 +15,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install llms-txt-generator --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill llms-txt-generator
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -34,7 +42,7 @@ npx "@opendirectory.dev/skills" install llms-txt-generator --target claude
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -43,7 +51,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -57,14 +65,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill llms-txt-generator
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/llms-txt-generator/README.md
+++ b/skills/llms-txt-generator/README.md
@@ -21,7 +21,7 @@ npx "@opendirectory.dev/skills" install llms-txt-generator --target claude
 npx skills add Varnan-Tech/opendirectory --skill llms-txt-generator
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/llms-txt-generator/README.md
+++ b/skills/llms-txt-generator/README.md
@@ -57,6 +57,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill llms-txt-generator
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/map-your-market/README.md
+++ b/skills/map-your-market/README.md
@@ -19,7 +19,7 @@ npx "@opendirectory.dev/skills" install map-your-market --target claude
 npx skills add Varnan-Tech/opendirectory --skill map-your-market
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/map-your-market/README.md
+++ b/skills/map-your-market/README.md
@@ -13,7 +13,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install map-your-market --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill map-your-market
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -32,7 +40,7 @@ npx "@opendirectory.dev/skills" install map-your-market --target claude
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -41,7 +49,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -55,14 +63,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill map-your-market
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/map-your-market/README.md
+++ b/skills/map-your-market/README.md
@@ -55,6 +55,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill map-your-market
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/meeting-brief-generator/README.md
+++ b/skills/meeting-brief-generator/README.md
@@ -16,7 +16,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install meeting-brief-generator --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill meeting-brief-generator
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -35,7 +43,7 @@ npx "@opendirectory.dev/skills" install meeting-brief-generator --target claude
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -44,7 +52,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -58,14 +66,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill meeting-brief-generator
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/meeting-brief-generator/README.md
+++ b/skills/meeting-brief-generator/README.md
@@ -22,7 +22,7 @@ npx "@opendirectory.dev/skills" install meeting-brief-generator --target claude
 npx skills add Varnan-Tech/opendirectory --skill meeting-brief-generator
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/meeting-brief-generator/README.md
+++ b/skills/meeting-brief-generator/README.md
@@ -58,6 +58,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill meeting-brief-generator
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/meta-ads-skill/README.md
+++ b/skills/meta-ads-skill/README.md
@@ -27,7 +27,7 @@ npx "@opendirectory.dev/skills" install meta-ads-skill --target claude
 npx skills add Varnan-Tech/opendirectory --skill meta-ads-skill
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/meta-ads-skill/README.md
+++ b/skills/meta-ads-skill/README.md
@@ -63,6 +63,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill meta-ads-skill
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/meta-ads-skill/README.md
+++ b/skills/meta-ads-skill/README.md
@@ -21,7 +21,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install meta-ads-skill --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill meta-ads-skill
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -40,7 +48,7 @@ npx "@opendirectory.dev/skills" install meta-ads-skill --target claude
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -49,7 +57,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -63,14 +71,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill meta-ads-skill
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/meta-tribeV2-skill/README.md
+++ b/skills/meta-tribeV2-skill/README.md
@@ -61,6 +61,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill meta-tribeV2-skill
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/meta-tribeV2-skill/README.md
+++ b/skills/meta-tribeV2-skill/README.md
@@ -19,7 +19,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install meta-tribeV2-skill --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill meta-tribeV2-skill
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -38,7 +46,7 @@ npx "@opendirectory.dev/skills" install meta-tribeV2-skill --target claude
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -47,7 +55,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -61,14 +69,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill meta-tribeV2-skill
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/meta-tribeV2-skill/README.md
+++ b/skills/meta-tribeV2-skill/README.md
@@ -25,7 +25,7 @@ npx "@opendirectory.dev/skills" install meta-tribeV2-skill --target claude
 npx skills add Varnan-Tech/opendirectory --skill meta-tribeV2-skill
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/newsletter-digest/README.md
+++ b/skills/newsletter-digest/README.md
@@ -58,6 +58,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill newsletter-digest
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/newsletter-digest/README.md
+++ b/skills/newsletter-digest/README.md
@@ -16,7 +16,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install newsletter-digest --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill newsletter-digest
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -35,7 +43,7 @@ npx "@opendirectory.dev/skills" install newsletter-digest --target claude
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -44,7 +52,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -58,14 +66,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill newsletter-digest
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/newsletter-digest/README.md
+++ b/skills/newsletter-digest/README.md
@@ -22,7 +22,7 @@ npx "@opendirectory.dev/skills" install newsletter-digest --target claude
 npx skills add Varnan-Tech/opendirectory --skill newsletter-digest
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/noise-to-linkedin-carousel/README.md
+++ b/skills/noise-to-linkedin-carousel/README.md
@@ -21,7 +21,7 @@ npx "@opendirectory.dev/skills" install noise-to-linkedin-carousel --target clau
 npx skills add Varnan-Tech/opendirectory --skill noise-to-linkedin-carousel
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/noise-to-linkedin-carousel/README.md
+++ b/skills/noise-to-linkedin-carousel/README.md
@@ -57,6 +57,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill noise-to-linkedin-carousel
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/noise-to-linkedin-carousel/README.md
+++ b/skills/noise-to-linkedin-carousel/README.md
@@ -15,7 +15,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install noise-to-linkedin-carousel --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill noise-to-linkedin-carousel
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -34,7 +42,7 @@ npx "@opendirectory.dev/skills" install noise-to-linkedin-carousel --target clau
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -43,7 +51,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -57,14 +65,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill noise-to-linkedin-carousel
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/noise2blog/README.md
+++ b/skills/noise2blog/README.md
@@ -58,6 +58,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill noise2blog
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/noise2blog/README.md
+++ b/skills/noise2blog/README.md
@@ -16,7 +16,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install noise2blog --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill noise2blog
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -35,7 +43,7 @@ npx "@opendirectory.dev/skills" install noise2blog --target claude
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -44,7 +52,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -58,14 +66,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill noise2blog
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/noise2blog/README.md
+++ b/skills/noise2blog/README.md
@@ -22,7 +22,7 @@ npx "@opendirectory.dev/skills" install noise2blog --target claude
 npx skills add Varnan-Tech/opendirectory --skill noise2blog
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/npm-downloads-to-leads/README.md
+++ b/skills/npm-downloads-to-leads/README.md
@@ -13,7 +13,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install npm-downloads-to-leads --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill npm-downloads-to-leads
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -32,7 +40,7 @@ npx "@opendirectory.dev/skills" install npm-downloads-to-leads --target claude
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -41,7 +49,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -55,14 +63,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill npm-downloads-to-leads
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/npm-downloads-to-leads/README.md
+++ b/skills/npm-downloads-to-leads/README.md
@@ -55,6 +55,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill npm-downloads-to-leads
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/npm-downloads-to-leads/README.md
+++ b/skills/npm-downloads-to-leads/README.md
@@ -19,7 +19,7 @@ npx "@opendirectory.dev/skills" install npm-downloads-to-leads --target claude
 npx skills add Varnan-Tech/opendirectory --skill npm-downloads-to-leads
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/oss-launch-kit/README.md
+++ b/skills/oss-launch-kit/README.md
@@ -21,7 +21,7 @@ npx "@opendirectory.dev/skills" install oss-launch-kit --target claude
 npx skills add Varnan-Tech/opendirectory --skill oss-launch-kit
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/oss-launch-kit/README.md
+++ b/skills/oss-launch-kit/README.md
@@ -57,6 +57,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill oss-launch-kit
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/oss-launch-kit/README.md
+++ b/skills/oss-launch-kit/README.md
@@ -15,7 +15,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install oss-launch-kit --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill oss-launch-kit
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -34,7 +42,7 @@ npx "@opendirectory.dev/skills" install oss-launch-kit --target claude
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -43,7 +51,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -57,14 +65,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill oss-launch-kit
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/outreach-sequence-builder/README.md
+++ b/skills/outreach-sequence-builder/README.md
@@ -16,7 +16,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install outreach-sequence-builder --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill outreach-sequence-builder
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -35,7 +43,7 @@ npx "@opendirectory.dev/skills" install outreach-sequence-builder --target claud
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -44,7 +52,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -58,14 +66,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill outreach-sequence-builder
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/outreach-sequence-builder/README.md
+++ b/skills/outreach-sequence-builder/README.md
@@ -58,6 +58,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill outreach-sequence-builder
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/outreach-sequence-builder/README.md
+++ b/skills/outreach-sequence-builder/README.md
@@ -22,7 +22,7 @@ npx "@opendirectory.dev/skills" install outreach-sequence-builder --target claud
 npx skills add Varnan-Tech/opendirectory --skill outreach-sequence-builder
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/position-me/README.md
+++ b/skills/position-me/README.md
@@ -23,7 +23,7 @@ npx "@opendirectory.dev/skills" install position-me --target claude
 npx skills add Varnan-Tech/opendirectory --skill position-me
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/position-me/README.md
+++ b/skills/position-me/README.md
@@ -59,6 +59,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill position-me
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/position-me/README.md
+++ b/skills/position-me/README.md
@@ -17,7 +17,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install position-me --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill position-me
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -36,7 +44,7 @@ npx "@opendirectory.dev/skills" install position-me --target claude
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -45,7 +53,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -59,14 +67,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill position-me
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/pr-description-writer/README.md
+++ b/skills/pr-description-writer/README.md
@@ -16,7 +16,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install pr-description-writer --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill pr-description-writer
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -35,7 +43,7 @@ npx "@opendirectory.dev/skills" install pr-description-writer --target claude
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -44,7 +52,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -58,14 +66,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill pr-description-writer
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/pr-description-writer/README.md
+++ b/skills/pr-description-writer/README.md
@@ -22,7 +22,7 @@ npx "@opendirectory.dev/skills" install pr-description-writer --target claude
 npx skills add Varnan-Tech/opendirectory --skill pr-description-writer
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/pr-description-writer/README.md
+++ b/skills/pr-description-writer/README.md
@@ -58,6 +58,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill pr-description-writer
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/pricing-finder/README.md
+++ b/skills/pricing-finder/README.md
@@ -15,7 +15,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install pricing-finder --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill pricing-finder
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -34,7 +42,7 @@ npx "@opendirectory.dev/skills" install pricing-finder --target claude
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -43,7 +51,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -57,14 +65,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill pricing-finder
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/pricing-finder/README.md
+++ b/skills/pricing-finder/README.md
@@ -21,7 +21,7 @@ npx "@opendirectory.dev/skills" install pricing-finder --target claude
 npx skills add Varnan-Tech/opendirectory --skill pricing-finder
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/pricing-finder/README.md
+++ b/skills/pricing-finder/README.md
@@ -57,6 +57,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill pricing-finder
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/pricing-page-psychology-audit/README.md
+++ b/skills/pricing-page-psychology-audit/README.md
@@ -65,6 +65,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill pricing-page-psychology-audit
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/pricing-page-psychology-audit/README.md
+++ b/skills/pricing-page-psychology-audit/README.md
@@ -23,7 +23,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install pricing-page-psychology-audit --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill pricing-page-psychology-audit
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -42,7 +50,7 @@ npx "@opendirectory.dev/skills" install pricing-page-psychology-audit --target c
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -51,7 +59,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -65,14 +73,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill pricing-page-psychology-audit
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/pricing-page-psychology-audit/README.md
+++ b/skills/pricing-page-psychology-audit/README.md
@@ -29,7 +29,7 @@ npx "@opendirectory.dev/skills" install pricing-page-psychology-audit --target c
 npx skills add Varnan-Tech/opendirectory --skill pricing-page-psychology-audit
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/product-update-logger/README.md
+++ b/skills/product-update-logger/README.md
@@ -21,7 +21,7 @@ npx "@opendirectory.dev/skills" install product-update-logger --target claude
 npx skills add Varnan-Tech/opendirectory --skill product-update-logger
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/product-update-logger/README.md
+++ b/skills/product-update-logger/README.md
@@ -15,7 +15,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install product-update-logger --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill product-update-logger
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -34,7 +42,7 @@ npx "@opendirectory.dev/skills" install product-update-logger --target claude
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -43,7 +51,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -57,14 +65,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill product-update-logger
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/product-update-logger/README.md
+++ b/skills/product-update-logger/README.md
@@ -57,6 +57,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill product-update-logger
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/producthunt-launch-kit/README.md
+++ b/skills/producthunt-launch-kit/README.md
@@ -22,7 +22,7 @@ npx "@opendirectory.dev/skills" install producthunt-launch-kit --target claude
 npx skills add Varnan-Tech/opendirectory --skill producthunt-launch-kit
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/producthunt-launch-kit/README.md
+++ b/skills/producthunt-launch-kit/README.md
@@ -58,6 +58,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill producthunt-launch-kit
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/producthunt-launch-kit/README.md
+++ b/skills/producthunt-launch-kit/README.md
@@ -16,7 +16,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install producthunt-launch-kit --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill producthunt-launch-kit
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -35,7 +43,7 @@ npx "@opendirectory.dev/skills" install producthunt-launch-kit --target claude
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -44,7 +52,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -58,14 +66,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill producthunt-launch-kit
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/reddit-icp-monitor/README.md
+++ b/skills/reddit-icp-monitor/README.md
@@ -22,7 +22,7 @@ npx "@opendirectory.dev/skills" install reddit-icp-monitor --target claude
 npx skills add Varnan-Tech/opendirectory --skill reddit-icp-monitor
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/reddit-icp-monitor/README.md
+++ b/skills/reddit-icp-monitor/README.md
@@ -16,7 +16,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install reddit-icp-monitor --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill reddit-icp-monitor
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -35,7 +43,7 @@ npx "@opendirectory.dev/skills" install reddit-icp-monitor --target claude
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -44,7 +52,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -58,14 +66,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill reddit-icp-monitor
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/reddit-icp-monitor/README.md
+++ b/skills/reddit-icp-monitor/README.md
@@ -58,6 +58,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill reddit-icp-monitor
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/reddit-post-engine/README.md
+++ b/skills/reddit-post-engine/README.md
@@ -22,7 +22,7 @@ npx "@opendirectory.dev/skills" install reddit-post-engine --target claude
 npx skills add Varnan-Tech/opendirectory --skill reddit-post-engine
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/reddit-post-engine/README.md
+++ b/skills/reddit-post-engine/README.md
@@ -58,6 +58,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill reddit-post-engine
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/reddit-post-engine/README.md
+++ b/skills/reddit-post-engine/README.md
@@ -16,7 +16,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install reddit-post-engine --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill reddit-post-engine
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -35,7 +43,7 @@ npx "@opendirectory.dev/skills" install reddit-post-engine --target claude
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -44,7 +52,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -58,14 +66,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill reddit-post-engine
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/schema-markup-generator/README.md
+++ b/skills/schema-markup-generator/README.md
@@ -22,7 +22,7 @@ npx "@opendirectory.dev/skills" install schema-markup-generator --target claude
 npx skills add Varnan-Tech/opendirectory --skill schema-markup-generator
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/schema-markup-generator/README.md
+++ b/skills/schema-markup-generator/README.md
@@ -58,6 +58,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill schema-markup-generator
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/schema-markup-generator/README.md
+++ b/skills/schema-markup-generator/README.md
@@ -16,7 +16,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install schema-markup-generator --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill schema-markup-generator
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -35,7 +43,7 @@ npx "@opendirectory.dev/skills" install schema-markup-generator --target claude
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -44,7 +52,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -58,14 +66,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill schema-markup-generator
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/sdk-adoption-tracker/README.md
+++ b/skills/sdk-adoption-tracker/README.md
@@ -13,7 +13,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install sdk-adoption-tracker --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill sdk-adoption-tracker
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -32,7 +40,7 @@ npx "@opendirectory.dev/skills" install sdk-adoption-tracker --target claude
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -41,7 +49,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -55,14 +63,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill sdk-adoption-tracker
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/sdk-adoption-tracker/README.md
+++ b/skills/sdk-adoption-tracker/README.md
@@ -19,7 +19,7 @@ npx "@opendirectory.dev/skills" install sdk-adoption-tracker --target claude
 npx skills add Varnan-Tech/opendirectory --skill sdk-adoption-tracker
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/sdk-adoption-tracker/README.md
+++ b/skills/sdk-adoption-tracker/README.md
@@ -55,6 +55,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill sdk-adoption-tracker
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/show-hn-writer/README.md
+++ b/skills/show-hn-writer/README.md
@@ -58,6 +58,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill show-hn-writer
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/show-hn-writer/README.md
+++ b/skills/show-hn-writer/README.md
@@ -22,7 +22,7 @@ npx "@opendirectory.dev/skills" install show-hn-writer --target claude
 npx skills add Varnan-Tech/opendirectory --skill show-hn-writer
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/show-hn-writer/README.md
+++ b/skills/show-hn-writer/README.md
@@ -16,7 +16,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install show-hn-writer --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill show-hn-writer
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -35,7 +43,7 @@ npx "@opendirectory.dev/skills" install show-hn-writer --target claude
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -44,7 +52,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -58,14 +66,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill show-hn-writer
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/store-listing-optimizer/README.md
+++ b/skills/store-listing-optimizer/README.md
@@ -15,7 +15,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install store-listing-optimizer --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill store-listing-optimizer
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -34,7 +42,7 @@ npx "@opendirectory.dev/skills" install store-listing-optimizer --target claude
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -43,7 +51,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -57,14 +65,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill store-listing-optimizer
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/store-listing-optimizer/README.md
+++ b/skills/store-listing-optimizer/README.md
@@ -57,6 +57,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill store-listing-optimizer
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/store-listing-optimizer/README.md
+++ b/skills/store-listing-optimizer/README.md
@@ -21,7 +21,7 @@ npx "@opendirectory.dev/skills" install store-listing-optimizer --target claude
 npx skills add Varnan-Tech/opendirectory --skill store-listing-optimizer
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/tweet-thread-from-blog/README.md
+++ b/skills/tweet-thread-from-blog/README.md
@@ -16,7 +16,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install tweet-thread-from-blog --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill tweet-thread-from-blog
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -35,7 +43,7 @@ npx "@opendirectory.dev/skills" install tweet-thread-from-blog --target claude
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -44,7 +52,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -58,14 +66,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill tweet-thread-from-blog
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/tweet-thread-from-blog/README.md
+++ b/skills/tweet-thread-from-blog/README.md
@@ -58,6 +58,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill tweet-thread-from-blog
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/tweet-thread-from-blog/README.md
+++ b/skills/tweet-thread-from-blog/README.md
@@ -22,7 +22,7 @@ npx "@opendirectory.dev/skills" install tweet-thread-from-blog --target claude
 npx skills add Varnan-Tech/opendirectory --skill tweet-thread-from-blog
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/twitter-GTM-find-skill/README.md
+++ b/skills/twitter-GTM-find-skill/README.md
@@ -61,6 +61,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill twitter-GTM-find-skill
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/twitter-GTM-find-skill/README.md
+++ b/skills/twitter-GTM-find-skill/README.md
@@ -19,7 +19,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install twitter-GTM-find-skill --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill twitter-GTM-find-skill
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -38,7 +46,7 @@ npx "@opendirectory.dev/skills" install twitter-GTM-find-skill --target claude
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -47,7 +55,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -61,14 +69,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill twitter-GTM-find-skill
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/twitter-GTM-find-skill/README.md
+++ b/skills/twitter-GTM-find-skill/README.md
@@ -25,7 +25,7 @@ npx "@opendirectory.dev/skills" install twitter-GTM-find-skill --target claude
 npx skills add Varnan-Tech/opendirectory --skill twitter-GTM-find-skill
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/vc-curated-match/README.md
+++ b/skills/vc-curated-match/README.md
@@ -57,6 +57,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill vc-curated-match
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/vc-curated-match/README.md
+++ b/skills/vc-curated-match/README.md
@@ -15,7 +15,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install vc-curated-match --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill vc-curated-match
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -34,7 +42,7 @@ npx "@opendirectory.dev/skills" install vc-curated-match --target claude
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -43,7 +51,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -57,14 +65,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill vc-curated-match
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/vc-curated-match/README.md
+++ b/skills/vc-curated-match/README.md
@@ -21,7 +21,7 @@ npx "@opendirectory.dev/skills" install vc-curated-match --target claude
 npx skills add Varnan-Tech/opendirectory --skill vc-curated-match
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/vc-finder/README.md
+++ b/skills/vc-finder/README.md
@@ -19,7 +19,7 @@ npx "@opendirectory.dev/skills" install vc-finder --target claude
 npx skills add Varnan-Tech/opendirectory --skill vc-finder
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/vc-finder/README.md
+++ b/skills/vc-finder/README.md
@@ -55,6 +55,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill vc-finder
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/vc-finder/README.md
+++ b/skills/vc-finder/README.md
@@ -13,7 +13,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install vc-finder --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill vc-finder
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -32,7 +40,7 @@ npx "@opendirectory.dev/skills" install vc-finder --target claude
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -41,7 +49,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -55,14 +63,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill vc-finder
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/vid-motion-graphics/README.md
+++ b/skills/vid-motion-graphics/README.md
@@ -15,7 +15,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install vid-motion-graphics --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill vid-motion-graphics
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -34,7 +42,7 @@ npx "@opendirectory.dev/skills" install vid-motion-graphics --target claude
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -43,7 +51,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -57,14 +65,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill vid-motion-graphics
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/vid-motion-graphics/README.md
+++ b/skills/vid-motion-graphics/README.md
@@ -21,7 +21,7 @@ npx "@opendirectory.dev/skills" install vid-motion-graphics --target claude
 npx skills add Varnan-Tech/opendirectory --skill vid-motion-graphics
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/vid-motion-graphics/README.md
+++ b/skills/vid-motion-graphics/README.md
@@ -57,6 +57,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill vid-motion-graphics
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/vid-product-launch/README.md
+++ b/skills/vid-product-launch/README.md
@@ -19,7 +19,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install vid-product-launch --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill vid-product-launch
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -38,7 +46,7 @@ npx "@opendirectory.dev/skills" install vid-product-launch --target claude
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -47,7 +55,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -61,14 +69,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill vid-product-launch
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/vid-product-launch/README.md
+++ b/skills/vid-product-launch/README.md
@@ -25,7 +25,7 @@ npx "@opendirectory.dev/skills" install vid-product-launch --target claude
 npx skills add Varnan-Tech/opendirectory --skill vid-product-launch
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/vid-product-launch/README.md
+++ b/skills/vid-product-launch/README.md
@@ -61,6 +61,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill vid-product-launch
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/vid-sizzle-reel/README.md
+++ b/skills/vid-sizzle-reel/README.md
@@ -19,7 +19,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install vid-sizzle-reel --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill vid-sizzle-reel
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -38,7 +46,7 @@ npx "@opendirectory.dev/skills" install vid-sizzle-reel --target claude
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -47,7 +55,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -61,14 +69,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill vid-sizzle-reel
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/vid-sizzle-reel/README.md
+++ b/skills/vid-sizzle-reel/README.md
@@ -61,6 +61,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill vid-sizzle-reel
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/vid-sizzle-reel/README.md
+++ b/skills/vid-sizzle-reel/README.md
@@ -25,7 +25,7 @@ npx "@opendirectory.dev/skills" install vid-sizzle-reel --target claude
 npx skills add Varnan-Tech/opendirectory --skill vid-sizzle-reel
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/where-your-customer-lives/README.md
+++ b/skills/where-your-customer-lives/README.md
@@ -21,7 +21,7 @@ npx "@opendirectory.dev/skills" install where-your-customer-lives --target claud
 npx skills add Varnan-Tech/opendirectory --skill where-your-customer-lives
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/where-your-customer-lives/README.md
+++ b/skills/where-your-customer-lives/README.md
@@ -15,7 +15,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install where-your-customer-lives --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill where-your-customer-lives
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -34,7 +42,7 @@ npx "@opendirectory.dev/skills" install where-your-customer-lives --target claud
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -43,7 +51,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -57,14 +65,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill where-your-customer-lives
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/where-your-customer-lives/README.md
+++ b/skills/where-your-customer-lives/README.md
@@ -57,6 +57,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill where-your-customer-lives
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/yc-intent-radar-skill/README.md
+++ b/skills/yc-intent-radar-skill/README.md
@@ -21,7 +21,7 @@ npx "@opendirectory.dev/skills" install yc-intent-radar-skill --target claude
 npx skills add Varnan-Tech/opendirectory --skill yc-intent-radar-skill
 ```
 
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
 
 ### Option C: Claude Desktop App
 

--- a/skills/yc-intent-radar-skill/README.md
+++ b/skills/yc-intent-radar-skill/README.md
@@ -57,6 +57,14 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+
+### Option E: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill yc-intent-radar-skill
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 

--- a/skills/yc-intent-radar-skill/README.md
+++ b/skills/yc-intent-radar-skill/README.md
@@ -15,7 +15,15 @@ No global install. Always runs the latest version.
 npx "@opendirectory.dev/skills" install yc-intent-radar-skill --target claude
 ```
 
-### Option B: Claude Desktop App
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill yc-intent-radar-skill
+```
+
+Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
+
+### Option C: Claude Desktop App
 
 <video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
 
@@ -34,7 +42,7 @@ npx "@opendirectory.dev/skills" install yc-intent-radar-skill --target claude
 
 > **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
 
-### Option C: Claude Code Native
+### Option D: Claude Code Native
 
 Run these commands inside Claude Code:
 
@@ -43,7 +51,7 @@ Run these commands inside Claude Code:
 /plugin install opendirectory-gtm-skills@opendirectory-marketplace
 ```
 
-### Option D: Manus AI
+### Option E: Manus AI
 
 <video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
 
@@ -57,14 +65,6 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 4. Confirm the import inside Manus AI.
 
 > If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
-
-### Option E: skills.sh
-
-```bash
-npx skills add Varnan-Tech/opendirectory --skill yc-intent-radar-skill
-```
-
-Auto-detects your installed agent. Adds `--global` to install for all projects instead of the current one.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 


### PR DESCRIPTION
## What changed

- skills.sh added as Option B in root README and all 61 skill READMEs
- README template script updated so new skills get the section automatically
- skills.sh badge added to root README

## Install commands

- All skills: `npx skills add Varnan-Tech/opendirectory`
- One skill: `npx skills add Varnan-Tech/opendirectory --skill <skill-name>`