### PR TITLE
feat(skills): add code-reviewer skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <br />
 
 <div align="center">
-  <img src="https://readme-typing-svg.demolab.com?font=Fira+Code&size=20&duration=3000&pause=800&color=58A6FF&center=true&vCenter=true&width=620&height=50&lines=61+Agent+Skills;Works+with+Claude%2C+Codex%2C+Gemini+CLI%2C+Manus+AI;Agent+Skills+for+Founders+Who+Hate+Marketing;Install+in+seconds.+No+setup+required." alt="Typing SVG" />
+  <img src="https://readme-typing-svg.demolab.com?font=Fira+Code&size=20&duration=3000&pause=800&color=58A6FF&center=true&vCenter=true&width=620&height=50&lines=62+Agent+Skills;Works+with+Claude%2C+Codex%2C+Gemini+CLI%2C+Manus+AI;Agent+Skills+for+Founders+Who+Hate+Marketing;Install+in+seconds.+No+setup+required." alt="Typing SVG" />
 </div>
 
 <br />
@@ -17,7 +17,7 @@
 <div align="center">
 
 [![npm version](https://img.shields.io/npm/v/@opendirectory.dev/skills.svg?style=flat-square)](https://www.npmjs.com/package/@opendirectory.dev/skills)
-[![Skills](https://img.shields.io/badge/skills-61-blue.svg?style=flat-square)](skills/)
+[![Skills](https://img.shields.io/badge/skills-62-blue.svg?style=flat-square)](skills/)
 [![Stars](https://img.shields.io/github/stars/Varnan-Tech/opendirectory?style=flat-square&color=yellow)](https://github.com/Varnan-Tech/opendirectory/stargazers)
 [![Contributors](https://img.shields.io/github/contributors/Varnan-Tech/opendirectory?style=flat-square&color=orange)](https://github.com/Varnan-Tech/opendirectory/graphs/contributors)
 [![Agents](https://img.shields.io/badge/agents-8-blueviolet.svg?style=flat-square)](#quick-start)
@@ -45,7 +45,7 @@ Or list all skills:
 ```bash
 npx "@opendirectory.dev/skills" list
 ```
-*61 specialized skills across GTM, growth, and developer tooling*
+*62 specialized skills across GTM, growth, and developer tooling*
 
 ### 2. Pick your agent
 ```bash
@@ -265,7 +265,7 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 
 ## All Skills
 
-61 skills across GTM, growth automation, technical marketing, and developer tooling.
+62 skills across GTM, growth automation, technical marketing, and developer tooling.
 
 <!-- SKILLS_LIST_START -->
 
@@ -542,6 +542,11 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
   <tr>
     <td><a href="skills/claude-md-generator"><code>claude-md-generator</code></a></td>
     <td>Reads your codebase and writes a CLAUDE.md that gives Claude Code the context it needs: build commands, code conventions, architecture notes, and gotchas. Stays under 200 lines.</td>
+    <td><code>1.0.0</code></td>
+  </tr>
+  <tr>
+    <td><a href="skills/code-reviewer"><code>code-reviewer</code></a></td>
+    <td>Review a diff or pull request and get back severity-ranked findings, each with a file:line reference, the quoted code, and a concrete fix. Built for signal over volume. It scopes to the code you changed, skips style nitpicks, catches over-engineering, and tells you when a change is clean instead of padding the list.</td>
     <td><code>1.0.0</code></td>
   </tr>
   <tr>

--- a/packages/cli/registry.json
+++ b/packages/cli/registry.json
@@ -40,6 +40,14 @@
     "path": "skills/claude-md-generator"
   },
   {
+    "name": "code-reviewer",
+    "description": "Language-agnostic, low-false-positive review of a diff or pull request.",
+    "tags": [],
+    "author": "OpenDirectory",
+    "version": "1.0.0",
+    "path": "skills/code-reviewer"
+  },
+  {
     "name": "cold-email-verifier",
     "description": "Use when the user wants to verify cold emails, enrich a lead list, or autonomously guess email addresses from a CSV using ValidEmail.",
     "tags": [

--- a/packages/cli/registry.json
+++ b/packages/cli/registry.json
@@ -41,8 +41,10 @@
   },
   {
     "name": "code-reviewer",
-    "description": "Language-agnostic, low-false-positive review of a diff or pull request.",
-    "tags": [],
+    "description": "Language-agnostic, low-false-positive code review.",
+    "tags": [
+      "Developer Tools"
+    ],
     "author": "OpenDirectory",
     "version": "1.0.0",
     "path": "skills/code-reviewer"

--- a/skills/code-reviewer/README.md
+++ b/skills/code-reviewer/README.md
@@ -1,0 +1,110 @@
+# code-reviewer
+
+Review a diff or pull request and get back severity-ranked findings, each with a file:line reference, the quoted code, and a concrete fix. Built for signal over volume. It scopes to the code you changed, skips style nitpicks, catches over-engineering, and tells you when a change is clean instead of padding the list.
+
+<!-- OPENDIRECTORY_INSTALL_START -->
+## Install
+
+### Option A: npx CLI (Recommended)
+
+No global install. Always runs the latest version.
+
+```bash
+npx "@opendirectory.dev/skills" install code-reviewer --target claude
+```
+
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill code-reviewer
+```
+
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
+
+### Option C: Claude Desktop App
+
+<video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
+
+**Step 1: Download the skill from GitHub**
+
+1. Copy the URL of this specific skill folder from your browser's address bar.
+2. Go to [download-directory.github.io](https://download-directory.github.io/).
+3. Paste the URL and click **Enter** to download.
+
+**Step 2: Install in Claude**
+
+1. Open your **Claude desktop app**.
+2. Go to the sidebar on the left side and click on the **Customize** section.
+3. Click on the **Skills** tab, then click on the **+** button to create a new skill.
+4. Choose **Upload a skill**, then drag and drop the `.zip` file or extracted folder.
+
+> **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
+
+### Option D: Claude Code Native
+
+Run these commands inside Claude Code:
+
+```bash
+/plugin marketplace add Varnan-Tech/opendirectory
+/plugin install opendirectory-gtm-skills@opendirectory-marketplace
+```
+
+### Option E: Manus AI
+
+<video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
+
+[**Install in Manus AI**](https://manus.im/import-skills?githubUrl=https%3A%2F%2Fgithub.com%2FVarnan-Tech%2Fopendirectory%2Ftree%2Fmain%2Fskills%2Fcode-reviewer&utm_source=opendirectory)
+
+Manus AI users can import a skill directly from its OpenDirectory skill page. This is the easiest path when you want Manus to pull the skill from GitHub for you.
+
+1. Open the skill you want from the [opendirectory homepage](https://opendirectory.dev).
+2. In the install panel, select the **Manus AI** tab.
+3. Click **Install in Manus AI** - this opens Manus with the skill GitHub URL already attached.
+4. Confirm the import inside Manus AI.
+
+> If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+<!-- OPENDIRECTORY_INSTALL_END -->
+
+
+## What it does
+
+Most review bots flood a PR with cosmetic comments and miss the one bug that breaks production. Only about 31% of bot-flagged issues lead to a real change before merge. This skill flips that ratio.
+
+- Scopes to the diff. It reviews the changed lines and the context needed to judge them. It does not comment on code you did not touch.
+- Reads intent. It checks the PR title, ticket, and commits, then judges whether the code does what the change intended.
+- Reviews in gating order: correctness, then security, then performance, then simplification.
+- Runs two passes. A broad pass captures every candidate. A filter pass drops anything weak, out of scope, or not worth acting on.
+- Anchors severity to concrete gates, not feel. Critical, High, Medium, Low map to clear merge actions.
+- Catches unnecessary complexity. It flags premature abstractions, dead code, and reinvented stdlib, with guards against over-simplification.
+
+## Output
+
+Each finding follows one shape:
+
+```
+### 🔴 [CRITICAL] SQL injection in user lookup
+**File:** api/users.py:42
+**Issue:** user_id is interpolated into the query, so a crafted value runs arbitrary SQL.
+**Evidence:**
+    query = f"SELECT * FROM users WHERE id = {user_id}"
+**Fix:** use a parameterized query:
+    cur.execute("SELECT * FROM users WHERE id = %s", (user_id,))
+```
+
+It ends with a verdict: Ready to Merge, Needs Attention, or Needs Work, plus counts by severity.
+
+## Usage
+
+Ask your agent to review a change:
+
+- "Review this PR before I merge it."
+- "Check this diff for security and performance issues."
+- "Is this code fine to ship?"
+
+The skill reads the diff with `git diff`, or you can paste the code directly.
+
+## Structure
+
+- `SKILL.md` is the review process.
+- `references/` holds the per-dimension detail, loaded by name: `correctness.md`, `security.md`, `performance.md`, `simplification.md`, `output.md`.
+- `evals/evals.json` holds test cases with assertions.

--- a/skills/code-reviewer/README.md
+++ b/skills/code-reviewer/README.md
@@ -70,7 +70,8 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 
 Most review bots flood a PR with cosmetic comments and miss the one bug that breaks production. Only about 31% of bot-flagged issues lead to a real change before merge. This skill flips that ratio.
 
-- Scopes to the diff. It reviews the changed lines and the context needed to judge them. It does not comment on code you did not touch.
+- Works in two modes. Diff mode reviews a PR, branch, or change and scopes to the touched lines. Codebase mode audits a whole repo, directory, or file by risk and reports what it covered.
+- Scopes to the diff in diff mode. It reviews the changed lines and the context needed to judge them. It does not comment on code you did not touch.
 - Reads intent. It checks the PR title, ticket, and commits, then judges whether the code does what the change intended.
 - Reviews in gating order: correctness, then security, then performance, then simplification.
 - Runs two passes. A broad pass captures every candidate. A filter pass drops anything weak, out of scope, or not worth acting on.
@@ -95,16 +96,22 @@ It ends with a verdict: Ready to Merge, Needs Attention, or Needs Work, plus cou
 
 ## Usage
 
-Ask your agent to review a change:
+Diff mode, to review a change:
 
 - "Review this PR before I merge it."
 - "Check this diff for security and performance issues."
 - "Is this code fine to ship?"
 
-The skill reads the diff with `git diff`, or you can paste the code directly.
+Codebase mode, to audit existing code:
+
+- "Review my codebase."
+- "Audit this repo for security issues."
+- "Review the routes/ directory."
+
+The skill reads the diff with `git diff`, walks the repo with `git ls-files`, or works on code you paste directly.
 
 ## Structure
 
-- `SKILL.md` is the review process.
-- `references/` holds the per-dimension detail, loaded by name: `correctness.md`, `security.md`, `performance.md`, `simplification.md`, `output.md`.
+- `SKILL.md` is the review process and the mode selection.
+- `references/` holds the detail, loaded by name: `correctness.md`, `security.md`, `performance.md`, `simplification.md`, `codebase.md`, `output.md`.
 - `evals/evals.json` holds test cases with assertions.

--- a/skills/code-reviewer/SKILL.md
+++ b/skills/code-reviewer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-reviewer
-description: Language-agnostic, low-false-positive review of a diff or pull request. Scopes to the changed code, checks correctness, security, performance, and unnecessary complexity, then returns severity-ranked findings with file:line evidence and a concrete fix. Use when asked to review code, review a PR or diff, run a security or performance audit, check a change before merging or deploying, or asked whether code looks okay. Trigger on "review this code", "review my PR", "check this diff", "security audit", "is this code fine", or sharing a diff to judge, even without the words "code review".
+description: Language-agnostic, low-false-positive code review. Reviews a diff or pull request, or audits a whole codebase, directory, or single file. Checks correctness, security, performance, and unnecessary complexity, then returns severity-ranked findings with file:line evidence and a concrete fix. Use when asked to review code, review a PR or diff, audit a codebase or repo, run a security or performance audit, check a change before merging or deploying, or asked whether code looks okay. Trigger on "review this code", "review my PR", "check this diff", "audit my codebase", "review the repo", "security audit", or "is this code fine", even without the words "code review".
 compatibility: [claude-code, gemini-cli, github-copilot]
 author: OpenDirectory
 version: 1.0.0
@@ -15,21 +15,29 @@ substantive change, and the dominant failure mode is "flood the PR with nitpicks
 bug." So the bias of this skill is **precision over recall: prefer reporting nothing over reporting a
 weak finding.** When the change is clean, say so and stop.
 
-## Scope: review the change, not the codebase
+## Scope: decide what to review first
 
-Review **only the changed lines and the code needed to judge them.** Do not comment on pre-existing
-code the author didn't touch, and do not propose unrelated refactors — that noise is exactly what
-makes reviews ignored. The exception is when a change *reveals* a latent bug in adjacent code that it
-now exercises; flag that, with the connection stated.
+Two modes. Read the request and pick one; when it's ambiguous, default to diff mode because it's the
+higher-precision job. Everything after this section (two-pass, dimensions, severity, output) applies
+to both.
 
-First, get the change and the intent:
-- Diff: `git diff <base>...<head>` (or the PR diff). If reviewing uncommitted work, `git diff` / `git diff --staged`.
+**Diff mode (default)** — a PR, branch, commit, staged work, or "review this change before I merge."
+Review **only the changed lines and the code needed to judge them.** Don't comment on pre-existing
+code the author didn't touch, and don't propose unrelated refactors — that noise is exactly what
+makes reviews ignored. The one exception: a change that *reveals* a latent bug in adjacent code it now
+exercises; flag that, with the connection stated. Get the change and the intent:
+- Diff: `git diff <base>...<head>` (or the PR diff). For uncommitted work, `git diff` / `git diff --staged`.
 - Intent: read the PR title/description, linked ticket, and commit messages. Most real bugs are
   *intent vs. implementation* mismatches — the code is internally fine but does the wrong thing. You
-  cannot catch those without knowing what the change was supposed to do.
-- Context: for any function/type/endpoint the diff changes, check its callers and other usages
-  (`grep`/repo search). Cross-file drift — a contract changed on one side only — is invisible if you
-  read the diff in isolation.
+  can't catch those without knowing what the change was supposed to do.
+- Context: for any function/type/endpoint the diff changes, check its callers (`grep`/repo search).
+  A contract changed on one side only is invisible if you read the diff in isolation.
+
+**Codebase mode** — "review my codebase / repo / this directory / this file," an audit, or a security
+pass over a whole project. There's no diff to anchor to, so you review by risk rather than line by
+line, and you report what you covered. Read [references/codebase.md](references/codebase.md) before
+starting; it covers how to map the project, prioritize high-risk surfaces, and report coverage
+honestly.
 
 ## The two-pass method
 
@@ -39,9 +47,10 @@ once. Split it — this is simpler and measurably more precise:
 1. **Pass A — capture.** Go dimension by dimension (below) and list *every* candidate concern,
    generously. Don't self-censor yet.
 2. **Pass B — filter.** For each candidate ask: *Is it real?* (can you point to the concrete failure
-   or cost), *Is it in scope?* (touches changed code), *Would I act on it?* (block the merge, or
-   genuinely improve the code). Drop everything that fails. Drop pure style/formatting/naming
-   preferences unless they cause an actual bug or real confusion. What survives is the review.
+   or cost), *Is it in scope?* (in the code under review — the diff, or the files in a codebase pass),
+   *Would I act on it?* (block the merge, or genuinely improve the code). Drop everything that fails.
+   Drop pure style/formatting/naming preferences unless they cause an actual bug or real confusion.
+   What survives is the review.
 
 ## Dimensions, in gating order
 

--- a/skills/code-reviewer/SKILL.md
+++ b/skills/code-reviewer/SKILL.md
@@ -90,7 +90,7 @@ End with a one-line **verdict** and counts:
 - **Needs Attention** — Medium findings; mergeable with judgment.
 - **Needs Work** — any Critical/High.
 
-`✅ Ready to Merge` · `🔴 Critical: 0  🟠 High: 0  🟡 Medium: 2  ⚪ Low: 1`
+`🟡 Needs Attention` · `🔴 Critical: 0  🟠 High: 0  🟡 Medium: 2  ⚪ Low: 1`
 
 If the change is clean, say so plainly — "No blocking issues; behavior matches intent." Don't
 manufacture findings to look thorough. A short, correct review is the best outcome.

--- a/skills/code-reviewer/SKILL.md
+++ b/skills/code-reviewer/SKILL.md
@@ -84,13 +84,6 @@ definitions + the finding template + verdict rules: [references/output.md](refer
 
 Emit findings in this shape (the fix is what makes a review actionable rather than just critical):
 
-```
-### [SEVERITY] <short title>
-**File:** path/to/file.ext:LINE
-**Issue:** what's wrong + the concrete consequence
-**Evidence:** the offending line(s), quoted
-**Fix:** the corrected code, or a precise change
-```
 
 End with a one-line **verdict** and counts:
 - **Ready to Merge** — nothing above Low.

--- a/skills/code-reviewer/SKILL.md
+++ b/skills/code-reviewer/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: code-reviewer
+description: Language-agnostic, low-false-positive review of a diff or pull request. Scopes to the changed code, checks correctness, security, performance, and unnecessary complexity, then returns severity-ranked findings with file:line evidence and a concrete fix. Use when asked to review code, review a PR or diff, run a security or performance audit, check a change before merging or deploying, or asked whether code looks okay. Trigger on "review this code", "review my PR", "check this diff", "security audit", "is this code fine", or sharing a diff to judge, even without the words "code review".
+compatibility: [claude-code, gemini-cli, github-copilot]
+author: OpenDirectory
+version: 1.0.0
+---
+
+# Code Reviewer
+
+You are a senior reviewer whose signal-to-noise ratio is the whole point. A review that flags ten
+cosmetic things and misses the one bug that pages someone at 3am is a failure, even though it looks
+busy. The research is blunt about this: across real PR bots only ~31% of flagged issues lead to a
+substantive change, and the dominant failure mode is "flood the PR with nitpicks, miss the critical
+bug." So the bias of this skill is **precision over recall: prefer reporting nothing over reporting a
+weak finding.** When the change is clean, say so and stop.
+
+## Scope: review the change, not the codebase
+
+Review **only the changed lines and the code needed to judge them.** Do not comment on pre-existing
+code the author didn't touch, and do not propose unrelated refactors — that noise is exactly what
+makes reviews ignored. The exception is when a change *reveals* a latent bug in adjacent code that it
+now exercises; flag that, with the connection stated.
+
+First, get the change and the intent:
+- Diff: `git diff <base>...<head>` (or the PR diff). If reviewing uncommitted work, `git diff` / `git diff --staged`.
+- Intent: read the PR title/description, linked ticket, and commit messages. Most real bugs are
+  *intent vs. implementation* mismatches — the code is internally fine but does the wrong thing. You
+  cannot catch those without knowing what the change was supposed to do.
+- Context: for any function/type/endpoint the diff changes, check its callers and other usages
+  (`grep`/repo search). Cross-file drift — a contract changed on one side only — is invisible if you
+  read the diff in isolation.
+
+## The two-pass method
+
+A single "find everything important but no false positives" instruction pulls in two directions at
+once. Split it — this is simpler and measurably more precise:
+
+1. **Pass A — capture.** Go dimension by dimension (below) and list *every* candidate concern,
+   generously. Don't self-censor yet.
+2. **Pass B — filter.** For each candidate ask: *Is it real?* (can you point to the concrete failure
+   or cost), *Is it in scope?* (touches changed code), *Would I act on it?* (block the merge, or
+   genuinely improve the code). Drop everything that fails. Drop pure style/formatting/naming
+   preferences unless they cause an actual bug or real confusion. What survives is the review.
+
+## Dimensions, in gating order
+
+Review in this order because it mirrors how much each can hurt you. Load the matching reference file
+when you reach that dimension — they hold the concrete patterns and language-agnostic examples.
+
+1. **Correctness** — gates everything else; this is where you spend most effort. Logic vs. stated
+   intent, error handling, edge cases (null/empty/boundary), concurrency/races, data-flow, and
+   API/contract changes that break callers. See [references/correctness.md](references/correctness.md).
+2. **Security** — injection, XSS, authz/authn gaps, secrets, SSRF, unsafe deserialization, etc.
+   See [references/security.md](references/security.md).
+3. **Performance** — only issues that bite at real scale: N+1 queries, accidental O(n²), unbounded
+   memory, missing pagination. See [references/performance.md](references/performance.md).
+4. **Simplification (the lazy-senior lens)** — over-engineering, premature abstraction, dead code,
+   needless config, code that's harder than the problem. Real value, but guard hard against
+   over-simplification (clarity > fewer lines; behavior must not change). See
+   [references/simplification.md](references/simplification.md).
+
+LLM reviewers are reliably good at the functional dimensions (1–3) and weaker, noisier judges of
+maintainability (4) — so hold dimension 4 to a higher bar before you report it.
+
+## Severity and output
+
+Severity from an LLM is unreliable when left to feel, so anchor it to concrete gates (full
+definitions + the finding template + verdict rules: [references/output.md](references/output.md)):
+
+- **Critical** — security hole, data loss/corruption, or a crash on a normal path. Blocks merge.
+- **High** — a real bug on a plausible path, or a contract break for callers. Fix before merge.
+- **Medium** — works today but will bite (missing edge case, perf cliff at scale, fragile coupling).
+- **Low** — genuine improvement, non-blocking. Keep these rare; they are where nitpick-noise hides.
+
+Emit findings in this shape (the fix is what makes a review actionable rather than just critical):
+
+```
+### [SEVERITY] <short title>
+**File:** path/to/file.ext:LINE
+**Issue:** what's wrong + the concrete consequence
+**Evidence:** the offending line(s), quoted
+**Fix:** the corrected code, or a precise change
+```
+
+End with a one-line **verdict** and counts:
+- **Ready to Merge** — nothing above Low.
+- **Needs Attention** — Medium findings; mergeable with judgment.
+- **Needs Work** — any Critical/High.
+
+`✅ Ready to Merge` · `🔴 Critical: 0  🟠 High: 0  🟡 Medium: 2  ⚪ Low: 1`
+
+If the change is clean, say so plainly — "No blocking issues; behavior matches intent." Don't
+manufacture findings to look thorough. A short, correct review is the best outcome.

--- a/skills/code-reviewer/evals/evals.json
+++ b/skills/code-reviewer/evals/evals.json
@@ -50,6 +50,19 @@
         "Does not flag cosmetic style issues as findings",
         "Provides file:line references for the findings"
       ]
+    },
+    {
+      "id": 4,
+      "name": "codebase-mode-risk-first",
+      "prompt": "Review my codebase. It's a small Express service, two files:\n\n```javascript\n// routes/notes.js\nrouter.get('/notes/:id', async (req, res) => {\n  const note = await db.query(`SELECT * FROM notes WHERE id = ${req.params.id}`);\n  res.json(note);\n});\nrouter.delete('/notes/:id', async (req, res) => {\n  await db.query('DELETE FROM notes WHERE id = $1', [req.params.id]);\n  res.sendStatus(204);\n});\n```\n\n```javascript\n// routes/users.js\nrouter.get('/users/:id', requireAuth, async (req, res) => {\n  const u = await db.query('SELECT id, name FROM users WHERE id = $1', [req.params.id]);\n  res.json(u);\n});\n```",
+      "expected_output": "Reviews by risk across both files. Flags the SQL injection in routes/notes.js (template-string query) as Critical. Flags the missing auth/ownership check on the notes routes (users.js uses requireAuth, notes.js does not, so anyone can read or delete any note) as High. Groups findings by file. Reports coverage. Does not drown the result in style nitpicks.",
+      "assertions": [
+        "Flags the SQL injection in routes/notes.js (interpolated req.params.id) at Critical severity",
+        "Flags the missing authentication/authorization on the notes routes (inconsistent with users.js requireAuth, enabling read/delete of any note)",
+        "Groups findings by file or subsystem rather than one flat list",
+        "Includes a coverage note describing what was reviewed",
+        "Does not pad the review with formatting or naming nitpicks"
+      ]
     }
   ]
 }

--- a/skills/code-reviewer/evals/evals.json
+++ b/skills/code-reviewer/evals/evals.json
@@ -1,0 +1,55 @@
+{
+  "skill_name": "code-reviewer",
+  "evals": [
+    {
+      "id": 0,
+      "name": "real-bug-not-nitpick",
+      "prompt": "Review this change before I merge it:\n\n```python\n# auth/users.py (diff)\ndef get_user(uid):\n    q = f\"SELECT * FROM users WHERE id = {uid}\"   # uid comes from request.args\n    row = db.execute(q).fetchone()\n    return row\n```\n\nThe variable `uid` is the raw value from `request.args['id']`.",
+      "expected_output": "Flags the SQL injection as Critical with a parameterized-query fix and file:line. Does NOT nitpick the short name `uid` or `q`, or other style. Verdict: Needs Work.",
+      "assertions": [
+        "Reports a SQL injection / injection finding at Critical (or highest) severity",
+        "Provides a concrete fix using a parameterized/bound query",
+        "Does NOT raise a variable-naming or formatting style complaint as a finding",
+        "Includes a file:line reference and quoted evidence",
+        "Ends with a verdict indicating the change should not merge as-is (Needs Work or equivalent)"
+      ]
+    },
+    {
+      "id": 1,
+      "name": "clean-diff-no-false-positives",
+      "prompt": "Can you review this small change? I think it's fine but want a second pair of eyes.\n\n```javascript\n// utils/format.js (diff)\nexport function formatPrice(cents) {\n  if (!Number.isInteger(cents) || cents < 0) {\n    throw new TypeError('cents must be a non-negative integer');\n  }\n  return `$${(cents / 100).toFixed(2)}`;\n}\n```",
+      "expected_output": "Recognizes the code is correct (validates input, handles the edge). Returns Ready to Merge with no findings, or at most a single optional Low. Does NOT manufacture findings to look thorough.",
+      "assertions": [
+        "Concludes the change is essentially clean / Ready to Merge",
+        "Reports zero Critical/High/Medium findings",
+        "Does not invent speculative or cosmetic findings to appear thorough",
+        "States plainly that there are no blocking issues"
+      ]
+    },
+    {
+      "id": 2,
+      "name": "over-engineering-yagni",
+      "prompt": "Review this new code I'm adding for a feature that sends one type of notification (email):\n\n```typescript\n// notify/index.ts (new file)\ninterface NotificationStrategy { send(to: string, body: string): Promise<void>; }\n\nclass EmailNotificationStrategy implements NotificationStrategy {\n  async send(to: string, body: string) { await emailClient.send(to, body); }\n}\n\nclass NotificationFactory {\n  static create(type: string): NotificationStrategy {\n    switch (type) {\n      case 'email': return new EmailNotificationStrategy();\n      default: throw new Error('unknown type');\n    }\n  }\n}\n\nexport async function notify(to: string, body: string) {\n  const s = NotificationFactory.create('email');\n  await s.send(to, body);\n}\n```\n\nThere is only email today and no concrete plan for other channels.",
+      "expected_output": "Flags the over-engineering / YAGNI: interface + factory + strategy for a single implementation with no second channel planned. Suggests inlining to a simple function, behavior-preserving. Severity Medium (not Critical/High). Does not claim a functional bug that isn't there.",
+      "assertions": [
+        "Identifies the single-implementation interface/factory/strategy as unnecessary complexity (YAGNI / over-engineering)",
+        "Suggests a simpler behavior-preserving form (e.g., inline to a plain function calling emailClient.send)",
+        "Assigns it Medium or Low severity, not Critical or High",
+        "Does not fabricate a correctness/security bug that the code does not have"
+      ]
+    },
+    {
+      "id": 3,
+      "name": "n-plus-one-and-intent",
+      "prompt": "Please review this PR. PR title: 'Return active users with their latest order total'.\n\n```go\n// handlers/users.go (diff)\nfunc ActiveUsers(db *sql.DB) ([]UserDTO, error) {\n    rows, _ := db.Query(\"SELECT id, name FROM users WHERE active = true\")\n    var out []UserDTO\n    for rows.Next() {\n        var u UserDTO\n        rows.Scan(&u.ID, &u.Name)\n        total, _ := orderTotal(db, u.ID) // runs a SELECT per user\n        u.OrderTotal = total\n        out = append(out, u)\n    }\n    return out, nil\n}\n```",
+      "expected_output": "Flags the N+1 query (orderTotal called per user in the loop) at scale, with a JOIN/batch fix. Also flags the ignored errors from db.Query and rows.Scan (correctness). Correctness/perf findings, not style. Verdict reflects fixable issues.",
+      "assertions": [
+        "Identifies the N+1 query pattern (per-user query inside the loop) as a performance finding",
+        "Suggests batching / JOIN / single-query fix",
+        "Flags at least one ignored error (the discarded err from Query or Scan) as a correctness issue",
+        "Does not flag cosmetic style issues as findings",
+        "Provides file:line references for the findings"
+      ]
+    }
+  ]
+}

--- a/skills/code-reviewer/evals/evals.json
+++ b/skills/code-reviewer/evals/evals.json
@@ -1,5 +1,6 @@
 {
   "skill_name": "code-reviewer",
+  "eval_count": 5,
   "evals": [
     {
       "id": 0,

--- a/skills/code-reviewer/references/codebase.md
+++ b/skills/code-reviewer/references/codebase.md
@@ -1,0 +1,50 @@
+# Codebase mode
+
+Reviewing a whole repo, a directory, or a single file is a different job from reviewing a diff. There's
+no change to anchor to, and a large codebase has more lines than you can meaningfully judge in one pass.
+Two failure modes to avoid: reading every line and drowning the real issues in a flat list of nitpicks,
+or skimming and silently missing the high-risk code. The fix is the same as everywhere else in this
+skill — precision over volume — applied with a risk-first plan and an honest coverage report.
+
+## 1. Map the project first
+Before reviewing anything, get the shape of it:
+- File list: `git ls-files` (or a tree). Note size — number of files, rough lines.
+- Languages and frameworks, entry points (`main`, server bootstrap, route definitions, CLI).
+- Where the trust boundaries are: anything that takes outside input.
+
+State up front what you'll cover. For a small file or directory, that's "all of it." For a large repo,
+that's "the highest-risk surfaces first" — and you name them.
+
+## 2. Prioritize by risk, not by directory order
+Spend effort where a bug hurts most. Review these surfaces first; they're where Critical/High live:
+- **Auth and authorization** — login, sessions, tokens, ownership checks, role gates on new actions.
+- **Input handlers** — HTTP/API routes, form/file/upload handlers, message consumers, anything parsing
+  outside input.
+- **Data access** — query building, ORM usage, migrations (irreversible/locking changes).
+- **Money and critical state** — billing, balances, inventory, anything where a wrong number is a real loss.
+- **Dangerous sinks** — shell/exec, file paths, deserialization, template rendering, crypto, secrets.
+- **Concurrency** — shared state, locks, background jobs, anything async touching the same data.
+Lower-risk code (pure formatting helpers, static config, presentational UI) gets a lighter pass or is
+skipped — say which.
+
+## 3. Review each area with the normal method
+Apply the same dimensions in the same order (correctness → security → performance → simplification),
+the same two-pass filter, the same severity gates, and the same finding format from `output.md`. The
+only change is scope: "in scope" means "in the files under review," not "in the diff."
+
+Cross-file checks matter more here than in a diff. Look for the same logic duplicated and drifted
+across files, a utility reimplemented instead of reused, and auth/validation applied on some endpoints
+but missing on others. Those are invisible when you read one file at a time.
+
+## 4. Group findings and report coverage honestly
+- Group findings by file or subsystem, most severe first — not one flat list.
+- End with a **coverage report**: which areas you reviewed in full, which you sampled, and which you
+  skipped and why. If the repo is too large for one pass, review the highest-risk slice, say so
+  plainly, and list what remains for a follow-up. Never imply you covered everything when you sampled.
+- A clean subsystem gets one line ("auth: reviewed, no issues"), not silence and not invented findings.
+
+## Calibration
+Precision still rules. An "audit" that returns 200 style comments is a failure, not thoroughness. Lead
+with Critical/High, keep Medium focused, and let Low be rare. If the user asks you to be exhaustive or
+to include style, widen the bar and say what you changed — but the default here is the same high-signal
+review as diff mode, spread across files by risk.

--- a/skills/code-reviewer/references/correctness.md
+++ b/skills/code-reviewer/references/correctness.md
@@ -1,0 +1,53 @@
+# Correctness
+
+The primary dimension. Most production incidents are correctness bugs, and most correctness bugs are
+the code doing something *other than what the change intended* — not exotic algorithm errors. Judge
+the diff against its stated intent (PR/ticket/commit), then against reality (nulls, empties, retries,
+concurrency). Patterns below are language-agnostic; the examples just illustrate the shape.
+
+## Intent vs. implementation
+The highest-value check. The code can be internally clean and still wrong.
+- Does the change actually do what the PR says? Off-by-one in a "fix the boundary" PR, a filter that
+  excludes the wrong side, a flag wired backwards.
+- Did it change a function/endpoint/type signature, return shape, or error contract that **callers
+  rely on**? Check the callers. A contract changed on one side only is a real bug even if both files
+  compile.
+
+## Error handling
+- **Swallowed errors.** Bare `catch {}` / `except: pass` / ignored error returns hide failures until
+  data is already corrupt. Errors should be handled or propagated, with enough context to debug.
+- **Unchecked results.** Using a lookup/parse/fetch result without checking it succeeded → null deref,
+  `IndexError`, reading a field off `undefined`. New external calls especially.
+- **Wrong-layer handling.** Catching everything at the top and logging "error occurred" loses which
+  operation failed and why. Catch specific, near the cause.
+- Go/Rust-style: an ignored `err` / unhandled `Result` is the same bug in different clothes.
+
+## Edge cases
+Walk the new code with the inputs nobody tested: empty collection, single element, zero/negative,
+absent optional field, duplicate, very large input, unicode, timezone/DST for dates. The "happy path
+works" demo hides these.
+
+## Concurrency & races
+Flag when changed code touches shared state without protection:
+- Check-then-act on shared data (TOCTOU): `if not exists: create` racing another caller.
+- Read-modify-write without a lock/transaction/atomic (counters, balances, `i++` on shared state).
+- `async`/await that assumes ordering it doesn't have; promises not awaited; missing `await` on a
+  call whose result or side-effect the next line depends on.
+- Shared mutable state captured by a closure or goroutine/thread.
+
+## Data flow & validation
+- Untrusted input reaching a sink without validation (overlaps Security — note it once, in whichever
+  dimension is more severe).
+- Type/unit confusion: seconds vs. ms, cents vs. dollars, 0-indexed vs. 1-indexed, string `"0"` truthy.
+- State that can desync: two fields that must move together but are updated in separate steps with a
+  failure point between them.
+
+## Tests (report only when the change clearly warrants them)
+New non-trivial logic, a bug fix, or a money/security/auth path should carry a test — ideally one
+that fails without the change. Don't demand tests for trivial or mechanical edits; that's noise.
+Frame as: "this branch has no test and would regress silently," not "coverage is low."
+
+## Calibration
+- Correctness findings are almost always worth reporting — this is the dimension to be thorough on.
+- Still require evidence: name the input or interleaving that triggers the failure. "This might break
+  with weird input" without a concrete case is a Pass-B casualty, not a finding.

--- a/skills/code-reviewer/references/output.md
+++ b/skills/code-reviewer/references/output.md
@@ -1,0 +1,78 @@
+# Severity, output format, and false-positive control
+
+## Why severity needs anchoring
+LLM reviewers agree with each other on *whether* something is a bug far more than on *how severe* it
+is — severity left to feel is the least reliable thing a reviewer produces. So decide severity by the
+concrete gate below, not by how bad it sounds. When unsure between two levels, the deciding question
+is **"does this block the merge?"** — yes → Critical/High, no → Medium/Low.
+
+| Severity | Gate (concrete) | Action |
+|----------|-----------------|--------|
+| 🔴 **Critical** | Security hole reachable from untrusted input; data loss/corruption; crash on a normal path. | Block merge. Fix now. |
+| 🟠 **High** | A real bug on a plausible path; a contract/API break for existing callers. | Fix before merge. |
+| 🟡 **Medium** | Works today but will bite: unhandled edge case, perf cliff at scale, fragile coupling, over-engineered new abstraction. | Fix before merge, or accept with a noted reason. |
+| ⚪ **Low** | Genuine but non-blocking improvement (minor cleanup, small simplification). | Optional. Keep these rare. |
+
+Asymmetry to aim for, drawn from how the better tools tune: be effectively 100% thorough on
+Critical/High (missing one is the real cost), and accept lower volume on Medium/Low (a missed nitpick
+costs nothing, a false one costs trust). Target: zero false positives at the Critical tier.
+
+## Finding format
+Each finding carries severity, location, the issue *with its consequence*, the quoted evidence, and a
+fix. The fix is the point — a finding the author can apply in one step is worth ten they have to
+re-derive.
+
+```
+### 🔴 [CRITICAL] SQL injection in user lookup
+**File:** api/users.py:42
+**Issue:** `user_id` comes straight from the request and is interpolated into the query, so a crafted
+value runs arbitrary SQL (auth bypass, full-table read).
+**Evidence:**
+    query = f"SELECT * FROM users WHERE id = {user_id}"
+**Fix:** use a parameterized query:
+    cur.execute("SELECT * FROM users WHERE id = %s", (user_id,))
+```
+
+## Report structure
+Group findings by dimension (Correctness → Security → Performance → Simplification), most severe
+first within each. Then a verdict line and counts.
+
+```
+## Code Review: <what was reviewed>
+
+<one-sentence summary: does it do what it intends, and the headline issue if any>
+
+## Correctness
+### 🟠 [HIGH] ...
+## Security
+### 🔴 [CRITICAL] ...
+## Performance
+(none)
+## Simplification
+### ⚪ [LOW] ...
+
+---
+**Verdict: 🔴 Needs Work** — 🔴 1  🟠 1  🟡 0  ⚪ 1
+```
+
+**Verdict rule:** any Critical/High → **Needs Work**. Only Medium → **Needs Attention**. Nothing above
+Low → **Ready to Merge**.
+
+## False-positive control (the discipline that makes this skill worth using)
+- **Only touched code.** Don't comment on lines the change didn't modify (unless the change makes
+  pre-existing code newly reachable/broken — then say how).
+- **Evidence or it didn't happen.** Every finding names the concrete failure, input, or cost. "This
+  could be problematic" with no scenario is not a finding.
+- **No style nits.** Formatting, import order, naming preferences, and "I'd write it differently" are
+  not findings unless they cause a bug or real confusion. Linters own that lane.
+- **Don't pad.** Do not invent Low findings to look thorough. Three real findings beat three real
+  plus seven cosmetic — the seven bury the three.
+- **Clean is a valid result.** If nothing meets the bar, say "No blocking issues; behavior matches
+  intent" and stop. That is a successful review, not a lazy one.
+- **De-dup.** One root cause repeated across several lines is one finding ("same pattern at lines
+  X, Y, Z"), not five.
+
+## When to broaden scope
+The defaults above are deliberately tight. If the user explicitly asks for a deeper or whole-codebase
+pass, a security-only audit, or "be picky about style too," follow that — adjust the bar to what they
+asked for and say what you changed.

--- a/skills/code-reviewer/references/performance.md
+++ b/skills/code-reviewer/references/performance.md
@@ -1,0 +1,36 @@
+# Performance
+
+Report performance only where it bites at **realistic scale** — a slow path that runs on 5 rows once
+a day is not a finding, the same path on every request over a growing table is. Always state the
+scale assumption ("at thousands of rows / per request"). Micro-optimizations and "this could be a
+hair faster" are Pass-B casualties; they're the easiest place to generate noise.
+
+## N+1 queries (the most common real one)
+A query to fetch a list, then one more query per item for related data. 100 items → 101 queries,
+each with network latency. Degrades silently until the table grows.
+- Spot it: a DB/API/`fetch` call **inside a loop** (or inside `.map`/list comprehension), where the
+  data could be fetched in one batched query.
+- Fix: eager-load / `JOIN` / `select_related`/`include` / `IN (...)` batch / DataLoader.
+
+## Algorithmic blowups
+- Nested loops over the same growing input → O(n²) where a set/map lookup makes it O(n). Classic:
+  `for x in a: if x in b` with `b` a list (linear scan) instead of a set.
+- Repeated work inside a loop that's invariant (recompiling a regex, re-reading a file, re-sorting).
+- Accidental quadratic string building in tight loops (where the language makes concatenation O(n)).
+
+## Memory & I/O
+- Loading an unbounded result set fully into memory (no pagination/streaming/`LIMIT`) — fine in dev,
+  OOM in prod.
+- Unbounded growth: a cache/list/map that's appended to forever with no eviction → slow leak.
+- Reading a large file/response fully when it could be streamed.
+- Chatty network: N sequential awaited calls that could be parallelized or batched.
+
+## Caching / redundant calls
+- The same expensive call repeated within one request that could be computed once.
+- A cache keyed wrong (too coarse → stale, too fine → never hits) — but only flag if you can show the
+  consequence.
+
+## Calibration
+Quantify the impact when you can ("each request now does N DB round-trips"). If you can't explain why
+it matters at scale, don't report it. Correctness of behavior always outranks speed — if a change is
+both wrong and slow, it's a correctness finding first.

--- a/skills/code-reviewer/references/security.md
+++ b/skills/code-reviewer/references/security.md
@@ -1,0 +1,44 @@
+# Security
+
+Security findings are the clearest "block the merge" cases, so they justify thorough checking — but
+hold them to evidence: name the untrusted input and the path it takes to the dangerous sink.
+Speculative "could be unsafe" without a reachable source→sink path is a Pass-B casualty. Patterns are
+language-agnostic; map them to the stack in front of you.
+
+## Injection (the dominant class)
+Untrusted input reaching an interpreter — SQL, shell, OS command, LDAP, NoSQL query, template engine.
+- **SQL:** any query built with string concatenation/interpolation of user input. Fix: parameterized
+  queries / bound params / ORM, never f-strings or `+`.
+- **Command:** user input in `exec`/`system`/`subprocess` with a shell. Fix: pass an argv array, no
+  shell; validate against an allowlist.
+- **NoSQL / template / LDAP:** same shape — user data changing query/template *structure* rather than
+  being passed as a value.
+
+## XSS / output encoding
+Untrusted data written into HTML/JS/DOM without escaping: `innerHTML`, `dangerouslySetInnerHTML`,
+unescaped template output, building DOM from user strings. Fix: textContent / auto-escaping templates
+/ sanitize (e.g. DOMPurify) when HTML is genuinely needed.
+
+## AuthZ / AuthN
+- A new endpoint/handler/mutation missing an authentication or ownership check — can user A act on
+  user B's resource? This is among the most common *real* bugs in feature PRs and easy to miss.
+- Authorization checked on the client but not the server.
+- Privilege/role check skipped on a new admin or destructive action.
+
+## Secrets & sensitive data
+- Hardcoded API keys, tokens, passwords, private keys in source or committed config. Fix: env/secret
+  manager. (If a real secret appears committed, flag Critical and recommend rotation — exposure ≠
+  removal.)
+- Secrets, tokens, PII, full card/SSN logged or returned in errors/responses.
+
+## Other high-value classes
+- **SSRF:** server fetches a user-supplied URL without an allowlist → internal network/metadata access.
+- **Unsafe deserialization:** `pickle`/Java native/`yaml.load`/`eval` on untrusted data → RCE.
+- **Path traversal:** user input in a file path without normalization+containment (`../`).
+- **Missing authz on direct object reference (IDOR):** `/api/doc/{id}` returning any id's data.
+- **Weak randomness for security:** `Math.random()`/`rand()` for tokens, IDs, password resets.
+- **Crypto misuse:** MD5/SHA1 for passwords (use bcrypt/argon2), hardcoded IV, ECB mode.
+
+## Calibration
+Exploitable + reachable from untrusted input → Critical. A defense-in-depth gap with no clear
+reachable path → Medium at most, and only if you can articulate the scenario.

--- a/skills/code-reviewer/references/simplification.md
+++ b/skills/code-reviewer/references/simplification.md
@@ -1,0 +1,63 @@
+# Simplification (the lazy-senior lens)
+
+Most reviewers only catch what's *broken*. This dimension catches what's *needless* — the abstraction
+nobody needed, the config no one will change, the 40 lines that should be 5. The best code is the
+code never written, and unnecessary complexity is itself a long-term bug: it's what someone has to
+decode at 3am.
+
+But this is the noisiest dimension if you let it be, because "simpler" is subjective and LLMs are
+weaker judges of maintainability than of correctness. So two rules gate everything here:
+
+1. **Behavior must not change.** Every simplification you suggest must be exactly behavior-preserving.
+   If you're not sure it preserves edge cases, don't suggest it.
+2. **Clarity over brevity.** The goal is *less to understand*, not *fewer characters*. Do not suggest
+   removing a helpful abstraction, a clarifying intermediate variable, or a guard clause just to
+   shrink line count. Collapsing readable code into a dense one-liner is a *worse* review than saying
+   nothing — see the over-simplification traps at the bottom.
+
+Only report a simplification when you can name what's not pulling its weight and why removing it is
+safe. When in doubt, drop it in Pass B.
+
+## What to flag
+
+**Speculative generality (YAGNI).** Machinery built for a future that isn't here:
+- An interface/abstract base/strategy with exactly one implementation, and no second one in sight.
+- A factory/builder/wrapper that only ever produces one thing.
+- A config value, parameter, or feature flag that's never varied (always the same constant).
+- A generic `<T>`/`options` bag where the code only uses one concrete case.
+- Fix: inline the single case; add the abstraction back the day the second case actually exists.
+
+**Dead / unreachable code introduced or revealed by the change:**
+- A new branch that can't be taken, a parameter passed but never read, an import/helper added but
+  unused, code after an unconditional return/throw.
+
+**Reinventing the platform.** A hand-rolled version of something the stdlib, language, or an
+*already-installed* dependency does — date math, deep clone, debounce, grouping, UUID, retry. Flag
+the few lines and name the built-in. (Don't suggest adding a *new* dependency for something a few
+lines do fine — that's the opposite mistake.)
+
+**Doing too much in one unit.** A function whose honest name would need "and" (`validateAndSaveAndNotify`)
+is doing several things and is hard to test and reuse. Suggest splitting along the seams.
+
+**Needless control-flow complexity:**
+- Nested ternaries — prefer an `if/else` chain or a lookup/switch; they're far easier to read.
+- Deep nesting that an early-return / guard clause flattens.
+- A boolean built up through several reassignments that one expression captures.
+- Re-checking a condition already guaranteed true.
+
+**Comment & duplication smells (low severity, report sparingly):**
+- A comment that restates the code, or worse, now contradicts it after the change.
+- The same non-trivial block copy-pasted in the diff that should be one helper — but only if the
+  duplication is real and the extraction is obviously clean.
+
+## Over-simplification traps — do NOT report these
+- Splitting a clear linear function into many tiny ones just to shrink each (over-decomposition).
+- Removing a guard clause, validation, or error branch — those are correctness, not clutter.
+- Replacing a readable loop with an unreadable clever reduce/comprehension.
+- "This whole module could be rewritten" — out of scope; review the change, not the architecture.
+- Naming/formatting preferences — not a finding unless the name is actively misleading.
+
+## Calibration
+Simplification findings are almost never Critical/High — they're improvements, not bugs. A genuinely
+over-engineered new abstraction is Medium; minor cleanups are Low and should be few. If a simpler
+form would also fix a bug, report it under Correctness instead.


### PR DESCRIPTION
Adds a developer skill: code-reviewer. It reviews code and returns severity-ranked findings, each with a file:line reference, the quoted code, and a concrete fix.

## Why

Most review bots flood a PR with cosmetic comments and miss the bug that breaks production. Across real PR bots, only about 31% of flagged issues lead to a substantive change before merge. This skill targets signal over volume: prefer reporting nothing over a weak finding.

## Two modes

- Diff mode (default). Reviews a PR, branch, commit, or staged change. Scopes to the touched lines and the context needed to judge them. Does not comment on untouched code.
- Codebase mode. Audits a whole repo, directory, or single file. Reviews by risk instead of by diff, then reports what it covered.

## What it does

- Reads intent. Checks the PR title, ticket, and commits, then judges intent against implementation.
- Reviews in gating order: correctness, security, performance, simplification.
- Runs two passes. A broad pass captures candidates. A filter pass drops anything weak, out of scope, or not worth acting on.
- Anchors severity to concrete gates: Critical, High, Medium, Low, each mapped to a merge action.
- Catches over-engineering and YAGNI, with guards against over-simplification.
- Language-agnostic. Examples span Python, JavaScript, TypeScript, and Go.

## Codebase mode method

- Maps the project first with git ls-files, languages, and entry points.
- Prioritizes high-risk surfaces: auth, input handlers, data access, money paths, dangerous sinks, concurrency.
- Runs cross-file checks a diff pass misses: duplicated logic that drifted, reinvented utils, auth applied on some routes but not others.
- Groups findings by file and ends with an honest coverage report. No silent gaps.

## Structure

- SKILL.md: the review process and mode selection, 103 lines.
- references/: per-dimension detail loaded by name (correctness, security, performance, simplification, codebase, output).
- evals/evals.json: 5 test cases with assertions (real bug vs nitpick, clean diff, over-engineering, N+1 plus intent mismatch, codebase risk-first).

## Validation

- scripts/validate-pr.ts passes. SKILL.md and README.md present, single-line description, no dangerous patterns, no scripts.
- packages/cli/registry.json regenerated to 62 skills.
- README skill count updated to 62.

Follows the basic-skill structure in CONTRIBUTING.md plus a references/ directory.