### PR TITLE
Add pql-framework skill for PLG and developer-first GTM

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <br />
 
 <div align="center">
-  <img src="https://readme-typing-svg.demolab.com?font=Fira+Code&size=20&duration=3000&pause=800&color=58A6FF&center=true&vCenter=true&width=620&height=50&lines=61+Agent+Skills;Works+with+Claude%2C+Codex%2C+Gemini+CLI%2C+Manus+AI;Agent+Skills+for+Founders+Who+Hate+Marketing;Install+in+seconds.+No+setup+required." alt="Typing SVG" />
+  <img src="https://readme-typing-svg.demolab.com?font=Fira+Code&size=20&duration=3000&pause=800&color=58A6FF&center=true&vCenter=true&width=620&height=50&lines=62+Agent+Skills;Works+with+Claude%2C+Codex%2C+Gemini+CLI%2C+Manus+AI;Agent+Skills+for+Founders+Who+Hate+Marketing;Install+in+seconds.+No+setup+required." alt="Typing SVG" />
 </div>
 
 <br />
@@ -17,7 +17,7 @@
 <div align="center">
 
 [![npm version](https://img.shields.io/npm/v/@opendirectory.dev/skills.svg?style=flat-square)](https://www.npmjs.com/package/@opendirectory.dev/skills)
-[![Skills](https://img.shields.io/badge/skills-61-blue.svg?style=flat-square)](skills/)
+[![Skills](https://img.shields.io/badge/skills-62-blue.svg?style=flat-square)](skills/)
 [![Stars](https://img.shields.io/github/stars/Varnan-Tech/opendirectory?style=flat-square&color=yellow)](https://github.com/Varnan-Tech/opendirectory/stargazers)
 [![Contributors](https://img.shields.io/github/contributors/Varnan-Tech/opendirectory?style=flat-square&color=orange)](https://github.com/Varnan-Tech/opendirectory/graphs/contributors)
 [![Agents](https://img.shields.io/badge/agents-8-blueviolet.svg?style=flat-square)](#quick-start)
@@ -45,7 +45,7 @@ Or list all skills:
 ```bash
 npx "@opendirectory.dev/skills" list
 ```
-*61 specialized skills across GTM, growth, and developer tooling*
+*62 specialized skills across GTM, growth, and developer tooling*
 
 ### 2. Pick your agent
 ```bash
@@ -265,7 +265,7 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 
 ## All Skills
 
-61 skills across GTM, growth automation, technical marketing, and developer tooling.
+62 skills across GTM, growth automation, technical marketing, and developer tooling.
 
 <!-- SKILLS_LIST_START -->
 
@@ -589,6 +589,11 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
   <tr>
     <td><a href="skills/domain-expired-opportunity-finder"><code>domain-expired-opportunity-finder</code></a></td>
     <td>Evaluate expired domain candidates against your niche. Get a conservative,</td>
+    <td><code>1.0.0</code></td>
+  </tr>
+  <tr>
+    <td><a href="skills/pql-framework"><code>pql-framework</code></a></td>
+    <td>Turn product behavior into a sales motion. Give this skill your product type and current telemetry setup, and it outputs a complete PQL system: pre-scoring exclusion filters, a two-dimensional signal library (behavioral + firmographic), a weighted scoring matrix with decay logic, A/B/C tiering, and Slack/CRM routing — including a founder-day-1 path that requires zero data warehouse infrastructure.</td>
     <td><code>1.0.0</code></td>
   </tr>
 </table>

--- a/packages/cli/registry.json
+++ b/packages/cli/registry.json
@@ -402,6 +402,14 @@
     "path": "skills/position-me"
   },
   {
+    "name": "pql-framework",
+    "description": "Build, calibrate, or audit a Product-Qualified Lead (PQL) scoring and routing system for PLG and developer-first companies.",
+    "tags": [],
+    "author": "Varnan",
+    "version": "1.0.0",
+    "path": "skills/pql-framework"
+  },
+  {
     "name": "pr-description-writer",
     "description": "Use when the user asks to write, draft, generate, or update a GitHub pull request description for the current branch.",
     "tags": [

--- a/skills/pql-framework/README.md
+++ b/skills/pql-framework/README.md
@@ -1,0 +1,75 @@
+# pql-framework
+
+Turn product behavior into a sales motion. Give this skill your product type and current telemetry setup, and it outputs a complete PQL system: pre-scoring exclusion filters, a two-dimensional signal library (behavioral + firmographic), a weighted scoring matrix with decay logic, A/B/C tiering, and Slack/CRM routing — including a founder-day-1 path that requires zero data warehouse infrastructure.
+
+<!-- OPENDIRECTORY_INSTALL_START -->
+## Install
+
+### Option A: npx CLI (Recommended)
+
+No global install. Always runs the latest version.
+
+```bash
+npx "@opendirectory.dev/skills" install pql-framework --target claude
+```
+
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill pql-framework
+```
+
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
+
+### Option C: Claude Desktop App
+
+**Step 1: Download the skill from GitHub**
+
+1. Copy the URL of this specific skill folder from your browser's address bar.
+2. Go to [download-directory.github.io](https://download-directory.github.io/).
+3. Paste the URL and click **Enter** to download.
+
+**Step 2: Install in Claude**
+
+1. Open your **Claude desktop app**.
+2. Go to the sidebar on the left side and click on the **Customize** section.
+3. Click on the **Skills** tab, then click on the **+** button to create a new skill.
+4. Choose **Upload a skill**, then drag and drop the `.zip` file or extracted folder.
+
+> **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
+
+### Option D: Claude Code Native
+
+Run these commands inside Claude Code:
+
+```bash
+/plugin marketplace add Varnan-Tech/opendirectory
+/plugin install opendirectory-gtm-skills@opendirectory-marketplace
+```
+
+### Option E: Manus AI
+
+[**Install in Manus AI**](https://manus.im/import-skills?githubUrl=https%3A%2F%2Fgithub.com%2FVarnan-Tech%2Fopendirectory%2Ftree%2Fmain%2Fskills%2Fpql-framework&utm_source=opendirectory)
+
+Manus AI users can import a skill directly from its OpenDirectory skill page.
+
+1. Open the skill you want from the [opendirectory homepage](https://opendirectory.dev).
+2. In the install panel, select the **Manus AI** tab.
+3. Click **Install in Manus AI** - this opens Manus with the skill GitHub URL already attached.
+4. Confirm the import inside Manus AI.
+<!-- OPENDIRECTORY_INSTALL_END -->
+
+
+## What It Does
+
+- Applies pre-scoring exclusion filters before any scoring runs (paid/no-upsell, expired trials, active escalations, competitors)
+- Builds a two-dimensional signal library: behavioral events (activation, depth, expansion, monetization proximity) + firmographic overlays (company size, role, funding stage, tech stack)
+- Outputs a weighted scoring matrix with default point values, decay windows (7-day halving, 14-day reset), and disqualifier overrides
+- Maps scores to A/B/C tiers with routing plays and SLA targets per tier
+- Provides a founder-scale Day 1 path: wire 2-3 events to Slack via PostHog/Mixpanel/Segment webhooks, no data warehouse required
+- Includes a measurement loop: conversion rate, time-to-first-touch, false positive rate, and 30-day model compounding cadence
+- Cross-references complementary Opendirectory skills: `sdk-adoption-tracker`, `company-radar`, `outreach-sequence-builder`
+
+## Key Insight
+
+Expansion signals (teammate invite → 2+ users, single-team → multi-team growth) outperform arbitrary usage thresholds as PQL triggers for developer-first products. These signals represent permanent organizational adoption state changes — not time-bounded behaviors — and should carry the highest scoring weight in your model.

--- a/skills/pql-framework/SKILL.md
+++ b/skills/pql-framework/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: pql-framework
+description: Build, calibrate, or audit a Product-Qualified Lead (PQL) scoring and routing system for PLG and developer-first companies. Use this skill whenever someone asks how to identify users ready to buy, which product events signal upgrade intent, how to route high-intent users to sales without a RevOps team, how to score users by product behavior, or any question about product-to-sales handoff, in-product conversion signals, or founder-scale PLG sales motions. Covers the full stack — signal library (behavioral + firmographic), pre-scoring exclusion filters, scoring matrix with decay and disqualifiers, A/B/C tiering, webhook routing to Slack/CRM, and a founder-day-1 path that requires zero data warehouse infrastructure.
+compatibility:
+  - claude-code
+  - gemini-cli
+  - github-copilot
+author: Varnan
+version: 1.0.0
+---
+
+# PQL Framework
+
+A Product-Qualified Lead is a user who experienced your product firsthand and showed buying intent through behavior — not someone who downloaded a PDF. Two dimensions are always required: **what they did** (behavioral signals) and **who they are** (firmographic fit). Neither alone is sufficient.
+
+## When to Use
+
+- Launching a PQL motion for the first time (including founder-scale, no RevOps)
+- Recalibrating a model generating too much noise or missing real buyers
+- Deciding which product events to instrument before you have full telemetry
+- Routing high-intent users to sales without a CRM pipeline
+- Auditing why PQL→paid conversion is low
+
+---
+
+## Step 0: Pre-Scoring Filters
+
+Run these **before** any scoring. Users that fail a filter are excluded entirely — not deprioritized in score. This prevents model noise from accounts that can never convert.
+
+| Exclude if | Reason |
+|---|---|
+| Already paid, no upgrade path available | No upsell potential |
+| Trial expired >14 days, no re-engagement | Intent has decayed; route to re-engagement nurture instead |
+| Active CS escalation or churn-save flag in progress | Sales outreach during a crisis destroys the relationship |
+| Confirmed competitor domain | Research accounts, not buyers |
+| Bot / spam pattern (no meaningful activity sequence) | Pollutes scoring |
+
+---
+
+## Step 1: Signal Library
+
+### Behavioral Signals (What They Did)
+
+**Activation** — has the user completed your core value loop?
+- Created first project / connected first integration / completed onboarding
+- Used the defining core feature at least once
+
+**Depth** — are they going deeper, not just exploring?
+- Used high-value features (features paid customers use disproportionately)
+- Repeated core feature use: 3+ sessions in a rolling 7-day window
+- Multi-product or multi-workspace usage
+
+**Expansion** — organizational buying intent (strongest signal class for developer-first PLG)
+- Invited a teammate → account now has 2+ users (Vercel's upsell trigger 1)
+- Account grew from single-team to multi-team usage (Vercel's upsell trigger 2)
+- Created shared workspaces, projects, or permission structures
+- Collaboration feature engagement (comments, sharing, role assignments)
+
+Expansion signals represent permanent organizational state changes. They outperform arbitrary usage thresholds because they surface the moment a team — not just an individual — is adopting the product.
+
+**Monetization proximity** — bumping into limits?
+- Visited pricing page 2+ times in 14 days
+- Clicked an upgrade CTA or viewed a paid feature gate
+- Approaching or hit a plan usage/seat/API limit
+
+### Firmographic Signals (Who They Are)
+
+Determine whether behavioral signals are worth acting on. High usage from a bad-fit account is noise.
+
+| Signal | Source options |
+|---|---|
+| Company size (10–500 employees is PLG sweet spot) | Clearbit, Apollo, LinkedIn |
+| Job title / role (decision-maker vs. individual contributor) | Email domain + enrichment |
+| Funding stage (funded = budget exists) | Crunchbase, Apollo |
+| Tech stack overlap | BuiltWith, GitHub profile analysis |
+| ICP vertical match | Email domain + enrichment |
+
+Use the `company-radar` skill for multi-source firmographic enrichment on signup email.
+
+---
+
+## Step 2: Scoring Model
+
+Start with a weighted point system. ML-based scoring only pays off after 100+ observed conversions.
+
+### Sample Scoring Matrix
+
+| Signal | Points | Notes |
+|---|---|---|
+| Completed activation milestone | +20 | Your defined "aha moment" event |
+| Core feature used 3x in 7 days | +15 | Rolling 7-day window |
+| Invited a teammate | +20 | Strongest early expansion signal |
+| Multi-team account growth | +25 | Organization-level buying intent |
+| Pricing page visited 2x in 14 days | +15 | Explicit upgrade consideration |
+| Hit plan usage limit | +20 | Forced upgrade consideration |
+| ICP firmographic match | +15 | Multiplier on behavioral signals |
+| No activation after 7 days of signup | −10 | Weak engagement signal |
+| Single session, never returned | −15 | No retention signal |
+
+**Default routing threshold:** score ≥ 60 → route to Tier A or B. Calibrate this after 30 days of conversion data.
+
+### Decay Logic
+
+Signals go stale. Apply time-based decay so old behavior doesn't perpetually inflate scores.
+
+- **7-day decay**: halve the score contribution of any event with no follow-on activity in 7 days
+- **14-day reset**: no product activity for 14 days → score drops to 0, account enters re-engagement pool
+- **Exception**: expansion signals (teammate invite, multi-team growth) do not decay — they are permanent organizational state changes, not time-bounded behaviors
+
+### Disqualifier Signals (Override High Scores)
+
+These suppress routing even when score is high:
+
+- Trial expiry warning fired + no login in 5 days → likely churning, not buying → re-engagement nurture
+- Support ticket marked critical or escalated → wrong moment for sales contact
+- Previously marked "not interested" by sales → respect the signal
+
+---
+
+## Step 3: Tiering
+
+| Tier | Score | Meaning | Motion |
+|---|---|---|---|
+| **A** | 80+ | High intent + ICP match | Personal outreach within 2 hours |
+| **B** | 60–79 | Moderate intent or partial ICP fit | Outreach within 24 hours |
+| **C** | 40–59 | Early signal, watch | Add to nurture; revisit in 7 days |
+| **Disqualified** | Any (triggered a disqualifier) | Excluded | Re-engagement nurture or no action |
+
+---
+
+## Step 4: Routing
+
+### Founder-Scale Path (No RevOps, No CRM Pipeline)
+
+**Day 1 — wire 2-3 signals to Slack:**
+1. Pick the 2-3 events most correlated with paid conversion in your product. If unknown, start with: `user_activated` + `teammate_invited` + `pricing_page_viewed_2x`
+2. Wire those events to a Slack webhook via your existing analytics tool:
+   - PostHog → Webhooks (free, open source)
+   - Mixpanel → Zapier → Slack
+   - Segment → webhook destination
+   - Amplitude → webhook integration
+3. When alert fires, founder reviews and sends a personal email within the hour
+4. Log outcome in Notion or Airtable: contacted → replied → converted → deal size
+
+**Day 30 — add firmographic filter:**
+1. Before the webhook fires, check ICP firmographic match (company size, job title)
+2. Use Clearbit Reveal or Apollo enrichment on the signup email domain
+3. Only fire the Slack alert when behavioral signal + ICP match are both true
+4. This cuts alert volume significantly without missing real buyers
+
+**Day 90 — add tiering:**
+1. Implement A/B/C tiers based on 30 days of conversion data
+2. Tier A → founder or AE reaches out personally
+3. Tier B → automated personalized email sequence (use `outreach-sequence-builder`)
+4. Tier C → add to drip nurture
+
+### Routing Channels by Tier
+
+| Tier | Channel | Response SLA | Owner |
+|---|---|---|---|
+| A | Slack alert + personal email or call | 2 hours | Founder / AE |
+| B | Automated personalized email sequence | 24 hours | Email automation |
+| C | Nurture drip | 7 days | Marketing |
+| Disqualified | Re-engagement nurture or no action | N/A | — |
+
+**Timing matters:** For PLG with fast sales cycles (<14 days), fire the alert while the user is still active in the product. Webhook routing achieves seconds-level latency — use it. For enterprise cycles (6+ months), batch or hourly scoring is sufficient.
+
+---
+
+## Step 5: Measurement Loop
+
+Track these weekly:
+
+| Metric | What it tells you |
+|---|---|
+| PQL → paid conversion rate | Model precision — are you flagging the right people? |
+| Time-to-first-touch after PQL fires | Routing speed — are you acting fast enough? |
+| Tier A conversion rate vs. Tier B | Is your tiering calibrated correctly? |
+| False positive rate (PQLs that never engage back) | Model noise — tighten ICP filter or raise threshold |
+| Disqualification rate | If >40% of scored users get excluded, pre-filters need tuning |
+
+**Compound the model:** After 30 days, identify users who converted to paid but were never flagged as PQLs. What signals did they share? Add those events to the scoring matrix. Repeat monthly.
+
+---
+
+## Tips
+
+- Expansion signals (teammate invite, multi-team growth) are the highest-signal PQL events for developer-first products. Vercel's CRO identified these two milestones as their primary enterprise upsell triggers — weight them heavily
+- Exclude ineligible accounts before scoring (pre-filter), not after (deprioritize). Keeping them in the model pollutes weights and wastes review time
+- Ship the simplest possible version first: one Slack webhook, two behavioral events, one firmographic filter. You'll learn more from 30 days of real routing than from building a perfect model upfront
+- For SDK/API-first products, use `sdk-adoption-tracker` to surface adoption events (new repos importing your SDK, rising download velocity) as behavioral signals in your PQL library
+- Re-evaluate scoring weights every 30 days using actual conversion data — the model calibrated at 100 users rarely holds at 10,000
+
+---
+
+## Complementary Opendirectory Skills
+
+| Skill | Use it to |
+|---|---|
+| `sdk-adoption-tracker` | Surface API/SDK adoption as behavioral signals (dev-first products) |
+| `company-radar` | Enrich accounts with firmographic data for the identity dimension |
+| `outreach-sequence-builder` | Build Tier A/B follow-up sequences triggered by PQL routing |
+| `where-your-customer-lives` | Define your ICP before configuring firmographic filters |
+| `map-your-market` | Validate ICP definition using real market signal data |

--- a/skills/pql-framework/evals/evals.json
+++ b/skills/pql-framework/evals/evals.json
@@ -1,0 +1,29 @@
+{
+  "skill_name": "pql-framework",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "I have a dev tool SaaS with a freemium plan. Users sign up, play around, but I don't know who is actually ready to buy. I'm the only salesperson right now and I can't talk to everyone. How do I figure out which users are high-intent without building some complicated scoring system?",
+      "expected_output": "Founder-scale PQL setup: pre-filter exclusions, 2-3 behavioral signals (activation + teammate invite + pricing page), Slack webhook routing, firmographic filter on ICP, and a manual-touch cadence for Tier A leads. Should be actionable without RevOps or data warehouse.",
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "We're getting tons of PQL alerts from our scoring system but our sales team says most of them are junk leads that never convert. Our current model fires when someone logs in 5 times in a week. What's wrong and how do we fix it?",
+      "expected_output": "Diagnosis: single-dimension behavioral scoring without firmographic filter, no pre-scoring exclusion logic, threshold too low/wrong signal. Fix: add ICP firmographic check, introduce expansion signals as higher-weight indicators, implement pre-model exclusion for paid/no-upsell accounts, apply decay logic, raise threshold.",
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "We're a developer-first API tool. Our users are individual developers who sign up, but we want to convert to team plans. What product events should we be tracking to know when an account is ready for a team plan upsell?",
+      "expected_output": "Focus on expansion signals: teammate invite (solo→pair), multi-team/workspace growth, collaboration feature usage, shared project creation. Reference Vercel's two-milestone model. Also cover: API usage growth, repeated core feature use, plan limit proximity. Suggest sdk-adoption-tracker for API-level signals.",
+      "files": []
+    },
+    {
+      "id": 4,
+      "prompt": "How should I handle users in my PQL model who are already paying customers? Should I score them differently or keep them in the same model?",
+      "expected_output": "Paid users with no upgrade path should be excluded BEFORE scoring (pre-model filter), not just deprioritized. Explain the two separate PQL model types: conversion-stage (free→paid) and expansion-stage (paid→upsell). Existing paid customers with expansion potential belong in an expansion PQL model, not the conversion model.",
+      "files": []
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds `pql-framework` skill: a complete product-qualified lead system for PLG and developer-first companies
- Two-dimensional scoring model (behavioral signals + firmographic fit), backed by deep research across 22 sources with adversarial claim verification
- Founder-scale Day 1 path using webhooks to Slack (PostHog, Mixpanel, Segment) with zero RevOps or data warehouse required

## What the skill covers

- Pre-scoring exclusion filters (paid/no-upsell, expired trials, active escalations, competitors excluded before any scoring runs)
- Signal library: activation, depth, expansion, and monetization proximity events
- Weighted scoring matrix with decay logic (7-day halving, 14-day reset) and disqualifier overrides
- A/B/C tiering with routing plays and SLA targets per tier
- Founder Day 1/30/90 implementation ladder
- Measurement loop: conversion rate, time-to-first-touch, false positive rate, 30-day compounding cadence
- Cross-references to `sdk-adoption-tracker`, `company-radar`, `outreach-sequence-builder`

## Key research finding

Expansion signals (teammate invite, single-team to multi-team growth) are the strongest PQL triggers for developer-first products. Vercel's CRO identified these two adoption milestones as the primary triggers for their PLG to enterprise upsell motion. Arbitrary usage thresholds (logins, page views) are lower-signal and should carry less weight.

## Test plan

- [x] `validate-pr.ts` passes: `pql-framework` is valid
- [x] `build-registry.ts` updated `packages/cli/registry.json` to include pql-framework (63 skills)
- [x] `update-readme.ts` regenerated root README
- [x] `update-contributing.ts` updated CONTRIBUTING.md
- [x] 4 eval test cases in `evals/evals.json` covering: founder-scale setup, noise/false-positive audit, developer API upsell signals, paid-user model exclusion