### PR TITLE
feat: add podcast-transcript-fetcher skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <br />
 
 <div align="center">
-  <img src="https://readme-typing-svg.demolab.com?font=Fira+Code&size=20&duration=3000&pause=800&color=58A6FF&center=true&vCenter=true&width=620&height=50&lines=61+Agent+Skills;Works+with+Claude%2C+Codex%2C+Gemini+CLI%2C+Manus+AI;Agent+Skills+for+Founders+Who+Hate+Marketing;Install+in+seconds.+No+setup+required." alt="Typing SVG" />
+  <img src="https://readme-typing-svg.demolab.com?font=Fira+Code&size=20&duration=3000&pause=800&color=58A6FF&center=true&vCenter=true&width=620&height=50&lines=62+Agent+Skills;Works+with+Claude%2C+Codex%2C+Gemini+CLI%2C+Manus+AI;Agent+Skills+for+Founders+Who+Hate+Marketing;Install+in+seconds.+No+setup+required." alt="Typing SVG" />
 </div>
 
 <br />
@@ -17,7 +17,7 @@
 <div align="center">
 
 [![npm version](https://img.shields.io/npm/v/@opendirectory.dev/skills.svg?style=flat-square)](https://www.npmjs.com/package/@opendirectory.dev/skills)
-[![Skills](https://img.shields.io/badge/skills-61-blue.svg?style=flat-square)](skills/)
+[![Skills](https://img.shields.io/badge/skills-62-blue.svg?style=flat-square)](skills/)
 [![Stars](https://img.shields.io/github/stars/Varnan-Tech/opendirectory?style=flat-square&color=yellow)](https://github.com/Varnan-Tech/opendirectory/stargazers)
 [![Contributors](https://img.shields.io/github/contributors/Varnan-Tech/opendirectory?style=flat-square&color=orange)](https://github.com/Varnan-Tech/opendirectory/graphs/contributors)
 [![Agents](https://img.shields.io/badge/agents-8-blueviolet.svg?style=flat-square)](#quick-start)
@@ -45,7 +45,7 @@ Or list all skills:
 ```bash
 npx "@opendirectory.dev/skills" list
 ```
-*61 specialized skills across GTM, growth, and developer tooling*
+*62 specialized skills across GTM, growth, and developer tooling*
 
 ### 2. Pick your agent
 ```bash
@@ -265,7 +265,7 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
 
 ## All Skills
 
-61 skills across GTM, growth automation, technical marketing, and developer tooling.
+62 skills across GTM, growth automation, technical marketing, and developer tooling.
 
 <!-- SKILLS_LIST_START -->
 
@@ -505,6 +505,11 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
   <tr>
     <td><a href="skills/meeting-brief-generator"><code>meeting-brief-generator</code></a></td>
     <td>Walk into every sales or business development call prepared. Give the skill a company name and it runs targeted research, synthesizes a 1-page brief, and optionally saves it to Notion.</td>
+    <td><code>1.0.0</code></td>
+  </tr>
+  <tr>
+    <td><a href="skills/podcast-transcript-fetcher"><code>podcast-transcript-fetcher</code></a></td>
+    <td>Fetch, search, and batch-transcribe transcripts from 5 top podcasts using a 3-tier approach: free sources, RSS+Whisper, and commercial API.</td>
     <td><code>1.0.0</code></td>
   </tr>
   <tr>

--- a/README.md
+++ b/README.md
@@ -509,8 +509,8 @@ Manus AI users can import a skill directly from its OpenDirectory skill page. Th
   </tr>
   <tr>
     <td><a href="skills/podcast-transcript-fetcher"><code>podcast-transcript-fetcher</code></a></td>
-    <td>Fetch, search, and batch-transcribe transcripts from 5 top podcasts using a 3-tier approach: free sources, RSS+Whisper, and commercial API.</td>
-    <td><code>1.0.0</code></td>
+    <td>Fetch, search, and batch-transcribe transcripts from 5 top podcasts. Tier 2 (RSS+Groq Whisper) is the recommended approach -- fast, free, and the most reliable. Tier 1 free sources are best-effort; Tier 3 Taddy API is the commercial/premium option.</td>
+    <td><code>1.1.0</code></td>
   </tr>
   <tr>
     <td><a href="skills/position-me"><code>position-me</code></a></td>

--- a/packages/cli/registry.json
+++ b/packages/cli/registry.json
@@ -392,9 +392,9 @@
   },
   {
     "name": "podcast-transcript-fetcher",
-    "description": "Fetch, search, and batch-transcribe transcripts from 5 top podcasts (Lenny's, Dwarkesh, Cheeky Pint, 20VC, A16z). Tier 2 (RSS+Groq Whisper) is the recommended approach.",
+    "description": "Use when fetching, searching, or analyzing transcripts from Lenny's Podcast, Dwarkesh Podcast, Cheeky Pint, 20VC, or A16z Podcast.",
     "tags": [
-      "Research"
+      "SEO"
     ],
     "author": "farizanjum",
     "version": "1.1.0",

--- a/packages/cli/registry.json
+++ b/packages/cli/registry.json
@@ -392,12 +392,12 @@
   },
   {
     "name": "podcast-transcript-fetcher",
-    "description": "Use when fetching, searching, or analyzing transcripts from Lenny's Podcast, Dwarkesh Podcast, Cheeky Pint, 20VC, or A16z Podcast.",
+    "description": "Fetch, search, and batch-transcribe transcripts from 5 top podcasts (Lenny's, Dwarkesh, Cheeky Pint, 20VC, A16z). Tier 2 (RSS+Groq Whisper) is the recommended approach.",
     "tags": [
-      "SEO"
+      "Research"
     ],
     "author": "farizanjum",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "path": "skills/podcast-transcript-fetcher"
   },
   {

--- a/packages/cli/registry.json
+++ b/packages/cli/registry.json
@@ -391,6 +391,16 @@
     "path": "skills/outreach-sequence-builder"
   },
   {
+    "name": "podcast-transcript-fetcher",
+    "description": "Use when fetching, searching, or analyzing transcripts from Lenny's Podcast, Dwarkesh Podcast, Cheeky Pint, 20VC, or A16z Podcast.",
+    "tags": [
+      "SEO"
+    ],
+    "author": "farizanjum",
+    "version": "1.0.0",
+    "path": "skills/podcast-transcript-fetcher"
+  },
+  {
     "name": "position-me",
     "description": "Elite Website Reviewer Agent for AEO, GEO, SEO, UI/UX Psychology, and Copywriting.",
     "tags": [

--- a/skills/podcast-transcript-fetcher/.env.example
+++ b/skills/podcast-transcript-fetcher/.env.example
@@ -2,5 +2,11 @@
 # Get your free API key at https://console.groq.com
 GROQ_API_KEY=""
 
+# Optional: Additional GROQ API keys for parallel transcription.
+# Add GROQ_API_KEY_2, GROQ_API_KEY_3, etc. and use --parallel N to transcribe
+# N episodes concurrently. Keys are assigned round-robin across workers.
+# GROQ_API_KEY_2=""
+# GROQ_API_KEY_3=""
+
 # Required for Taddy API (Tier 3) — commercial, optional
 # TADDY_API_KEY=""

--- a/skills/podcast-transcript-fetcher/.env.example
+++ b/skills/podcast-transcript-fetcher/.env.example
@@ -1,0 +1,6 @@
+# Required for RSS + Whisper transcription (Tier 2)
+# Get your free API key at https://console.groq.com
+GROQ_API_KEY=""
+
+# Required for Taddy API (Tier 3) — commercial, optional
+# TADDY_API_KEY=""

--- a/skills/podcast-transcript-fetcher/README.md
+++ b/skills/podcast-transcript-fetcher/README.md
@@ -1,0 +1,210 @@
+# Podcast Transcript Fetcher
+
+> Fetch, search, and batch-transcribe transcripts from 5 top podcasts using a 3-tier approach: free sources, RSS+Whisper, and commercial API.
+
+[![opendirectory](https://img.shields.io/badge/opendirectory-skill-blue)](https://opendirectory.dev)
+[![version](https://img.shields.io/badge/version-1.0.0-green)](https://github.com/Varnan-Tech/opendirectory)
+[![license](https://img.shields.io/badge/license-MIT-orange)](https://opensource.org/licenses/MIT)
+
+**Supported podcasts:** Lenny's Podcast, Dwarkesh Podcast, Cheeky Pint, 20VC (20 Minutes VC), A16z Podcast
+
+---
+
+<!-- OPENDIRECTORY_INSTALL_START -->
+## Install
+
+### Option A: npx CLI (Recommended)
+
+No global install. Always runs the latest version.
+
+```bash
+npx "@opendirectory.dev/skills" install podcast-transcript-fetcher --target claude
+```
+
+### Option B: skills.sh
+
+```bash
+npx skills add Varnan-Tech/opendirectory --skill podcast-transcript-fetcher
+```
+
+Requires Node.js. Add `--global` to install to `~/.claude/skills/` instead of the current project.
+
+### Option C: Claude Desktop App
+
+<video src="https://github.com/user-attachments/assets/cea8b565-2002-4a87-8857-d902bfcfdc1c" controls width="100%"></video>
+
+**Step 1: Download the skill from GitHub**
+
+1. Copy the URL of this specific skill folder from your browser's address bar.
+2. Go to [download-directory.github.io](https://download-directory.github.io/).
+3. Paste the URL and click **Enter** to download.
+
+**Step 2: Install in Claude**
+
+1. Open your **Claude desktop app**.
+2. Go to the sidebar on the left side and click on the **Customize** section.
+3. Click on the **Skills** tab, then click on the **+** button to create a new skill.
+4. Choose **Upload a skill**, then drag and drop the `.zip` file or extracted folder.
+
+> **Note:** For some skills, the `SKILL.md` file might be located inside a subfolder. Always upload the specific folder that contains the `SKILL.md` file.
+
+### Option D: Claude Code Native
+
+Run these commands inside Claude Code:
+
+```bash
+/plugin marketplace add Varnan-Tech/opendirectory
+/plugin install opendirectory-gtm-skills@opendirectory-marketplace
+```
+
+### Option E: Manus AI
+
+<video src="https://github.com/user-attachments/assets/17cbee2a-9e17-4bd4-ac46-68e0e92ffab4" controls width="100%"></video>
+
+[**Install in Manus AI**](https://manus.im/import-skills?githubUrl=https%3A%2F%2Fgithub.com%2FVarnan-Tech%2Fopendirectory%2Ftree%2Fmain%2Fskills%2Fpodcast-transcript-fetcher&utm_source=opendirectory)
+
+Manus AI users can import a skill directly from its OpenDirectory skill page. This is the easiest path when you want Manus to pull the skill from GitHub for you.
+
+1. Open the skill you want from the [opendirectory homepage](https://opendirectory.dev).
+2. In the install panel, select the **Manus AI** tab.
+3. Click **Install in Manus AI** - this opens Manus with the skill GitHub URL already attached.
+4. Confirm the import inside Manus AI.
+
+> If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
+<!-- OPENDIRECTORY_INSTALL_END -->
+
+
+## Quick Start
+
+```bash
+# Set up Python dependencies
+pip install requests python-dotenv
+
+# Copy and fill in your API key
+cp .env.example .env
+# Then edit .env with your GROQ_API_KEY
+
+# Get the latest Lenny's Podcast transcript
+python scripts/get_transcript.py "Lenny's Podcast" --latest
+
+# Search across ALL podcasts by keyword
+python scripts/get_transcript.py --search "Marc Andreessen"
+
+# Batch-transcribe last 3 episodes
+python scripts/get_transcript.py "Dwarkesh Podcast" --last 3
+```
+
+## Transcription Methods
+
+| Method | Cost | Speed | Quality | Setup |
+|--------|------|-------|---------|-------|
+| Free sources | $0 | Instant | Varies | None |
+| Groq Whisper | Free tier | ~10s/hr audio | 2.7% WER | `pip install groq` + API key |
+| Local faster-whisper | $0 (compute) | ~1.5x realtime | 2.7% WER | `pip install faster-whisper` |
+| Taddy API | $75/mo+ | Instant | High | `TADDY_API_KEY` |
+
+## Prerequisites
+
+- **Python 3.10+**
+- **ffmpeg** — for audio compression (Groq's 25 MB limit)
+  - Windows: `winget install ffmpeg` or `scoop install ffmpeg`
+  - macOS: `brew install ffmpeg`
+  - Linux: `apt install ffmpeg`
+- **Groq API key** — free at [console.groq.com](https://console.groq.com)
+- Works with: **Claude Code · OpenCode · Codex CLI · Gemini CLI · Cursor**
+
+## Usage
+
+### Single Episode
+
+```bash
+# Get latest episode (auto-detects best method)
+python scripts/get_transcript.py "Lenny's Podcast" --latest
+
+# Specific episode by title
+python scripts/get_transcript.py 20vc --episode "Sam Altman"
+
+# Force a specific method
+python scripts/get_transcript.py a16z --latest --method whisper
+
+# Save to file
+python scripts/get_transcript.py lennys --latest --output episode.md
+```
+
+### Cross-Podcast Search
+
+```bash
+# Find episodes by keyword across all 5 podcasts
+python scripts/get_transcript.py --search "regulation"
+
+# Search by guest name
+python scripts/get_transcript.py --guest "Marc Andreessen"
+
+# Filter to one podcast
+python scripts/get_transcript.py "Lenny's Podcast" --search "vibe coding"
+```
+
+### Batch Transcription
+
+```bash
+# Transcribe last 5 episodes
+python scripts/get_transcript.py "20vc" --last 5
+
+# Search + auto-transcribe top matches
+python scripts/get_transcript.py --search "AI safety" --transcribe --transcribe-count 5
+```
+
+## How It Works
+
+```
+User provides podcast + episode
+      ↓
+Tier 1: Free sources (GitHub archive, PodScripts, YouTube)
+  → Found? Return transcript instantly
+  → Not found? Fall through
+      ↓
+Tier 2: RSS + Whisper transcription
+  → Download MP3 from podcast RSS feed
+  → Compress if >25 MB (ffmpeg)
+  → Transcribe via Groq Whisper API
+      ↓
+Tier 3: Taddy API (commercial fallback)
+  → Requires TADDY_API_KEY
+```
+
+Search and batch features build on Tier 2:
+- **Search** scans RSS metadata (titles + descriptions) across all podcasts — instant, no API key needed
+- **Batch** downloads and transcribes the last N episodes in sequence
+- **Pipeline** chains search results into batch transcription
+
+## Project Structure
+
+```
+podcast-transcript-fetcher/
+├── SKILL.md                ← AI instructions (the brain)
+├── README.md               ← This file
+├── package.json            ← Skill metadata
+├── .env.example            ← Template for API keys
+├── scripts/
+│   ├── get_transcript.py   ← Core CLI (3-tier transcript fetcher)
+│   └── podcasts.json       ← Podcast registry (RSS feeds, sources)
+└── references/
+    └── podcasts.md         ← Detailed source documentation
+```
+
+## Use with AI Agents
+
+Once you have a transcript, ask your AI agent to analyze it:
+
+> "Summarize this transcript from Lenny's Podcast"
+> "Extract 3 actionable insights from this 20VC episode"
+> "Compare the Dwarkesh and A16z takes on AI safety"
+> "Find all episodes where they discuss [topic]"
+
+---
+
+## Contributing
+
+Want to add more podcasts? Open a PR or issue at the [OpenDirectory repo](https://github.com/Varnan-Tech/opendirectory).
+
+To add a podcast, just add an entry to `scripts/podcasts.json` with the podcast name, RSS feed URL, available transcript sources, and a slug. See the existing entries for the format.

--- a/skills/podcast-transcript-fetcher/README.md
+++ b/skills/podcast-transcript-fetcher/README.md
@@ -1,6 +1,6 @@
 # Podcast Transcript Fetcher
 
-> Fetch, search, and batch-transcribe transcripts from 5 top podcasts using a 3-tier approach: free sources, RSS+Whisper, and commercial API.
+> Fetch, search, and batch-transcribe transcripts from 5 top podcasts. Tier 2 (RSS+Groq Whisper) is the recommended approach -- fast, free, and the most reliable. Tier 1 free sources are best-effort; Tier 3 Taddy API is the commercial/premium option.
 
 [![opendirectory](https://img.shields.io/badge/opendirectory-skill-blue)](https://opendirectory.dev)
 [![version](https://img.shields.io/badge/version-1.0.0-green)](https://github.com/Varnan-Tech/opendirectory)
@@ -63,21 +63,18 @@ Run these commands inside Claude Code:
 
 [**Install in Manus AI**](https://manus.im/import-skills?githubUrl=https%3A%2F%2Fgithub.com%2FVarnan-Tech%2Fopendirectory%2Ftree%2Fmain%2Fskills%2Fpodcast-transcript-fetcher&utm_source=opendirectory)
 
-Manus AI users can import a skill directly from its OpenDirectory skill page. This is the easiest path when you want Manus to pull the skill from GitHub for you.
-
-1. Open the skill you want from the [opendirectory homepage](https://opendirectory.dev).
+Manus AI users can import a skill directly from its OpenDirectory skill page.
+1. Open the skill from the [opendirectory homepage](https://opendirectory.dev).
 2. In the install panel, select the **Manus AI** tab.
-3. Click **Install in Manus AI** - this opens Manus with the skill GitHub URL already attached.
+3. Click **Install in Manus AI**.
 4. Confirm the import inside Manus AI.
-
-> If your Manus workspace prefers file uploads, use the **Download** tab instead and upload the downloaded `.skill.zip` file inside Manus.
 <!-- OPENDIRECTORY_INSTALL_END -->
 
 
 ## Quick Start
 
 ```bash
-# Set up Python dependencies
+# Install Python dependencies
 pip install requests python-dotenv
 
 # Copy and fill in your API key
@@ -96,12 +93,12 @@ python scripts/get_transcript.py "Dwarkesh Podcast" --last 3
 
 ## Transcription Methods
 
-| Method | Cost | Speed | Quality | Setup |
-|--------|------|-------|---------|-------|
-| Free sources | $0 | Instant | Varies | None |
-| Groq Whisper | Free tier | ~10s/hr audio | 2.7% WER | `pip install groq` + API key |
-| Local faster-whisper | $0 (compute) | ~1.5x realtime | 2.7% WER | `pip install faster-whisper` |
-| Taddy API | $75/mo+ | Instant | High | `TADDY_API_KEY` |
+| Method | Cost | Speed | Quality | Setup | Recommendation |
+|--------|------|-------|---------|-------|---------------|
+| Free sources | $0 | Instant | Varies | None | Best-effort, limited availability |
+| Groq Whisper (Tier 2) | Free tier | ~10s/hr audio | 2.7% WER | `pip install groq` + API key | **RECOMMENDED** |
+| Local faster-whisper | $0 (compute) | ~1.5x realtime | 2.7% WER | `pip install faster-whisper` | Offline alternative |
+| Taddy API (Tier 3) | $75/mo+ | Instant | High | `TADDY_API_KEY` | Premium / commercial |
 
 ## Prerequisites
 
@@ -154,47 +151,26 @@ python scripts/get_transcript.py "20vc" --last 5
 python scripts/get_transcript.py --search "AI safety" --transcribe --transcribe-count 5
 ```
 
-### Parallel Transcription
-
-Speed up batch and pipeline jobs with the `--parallel N` flag:
-
-```bash
-# Set up multiple API keys (optional -- round-robin across workers)
-export GROQ_API_KEY="gsk_..."
-export GROQ_API_KEY_2="gsk_..."
-export GROQ_API_KEY_3="gsk_..."
-
-# Batch-transcribe 12 episodes with 3 parallel workers
-python scripts/get_transcript.py "Dwarkesh Podcast" --last 12 --parallel 3
-
-# Search pipeline with parallel transcription
-python scripts/get_transcript.py --search "AI safety" --transcribe --transcribe-count 10 --parallel 3
-```
-
-**How it works:**
-- Each worker independently downloads, compresses, and transcribes one episode
-- API keys are assigned round-robin across workers (`GROQ_API_KEY`, `GROQ_API_KEY_2`, ...)
-- Groq rate limit: ~30 req/min per key → 3 keys × 3 workers = ~90 req/min
-- Default `--parallel 1` maintains sequential backward-compatible behavior
-- Requires ffmpeg (for audio compression under Groq's 25 MB limit)
-- Output files are written independently with unique filenames (no contention)
-
 ## How It Works
 
 ```
 User provides podcast + episode
       ↓
-Tier 1: Free sources (GitHub archive, PodScripts, YouTube)
-  → Found? Return transcript instantly
-  → Not found? Fall through
+Tier 1: Free sources (best-effort, limited availability)
+  → Lenny's: GitHub archive (269 transcripts)
+  → Others: website scrape, Substack PDF
+  → Found? Return instantly
+  → Not found? Fall through to Tier 2
       ↓
-Tier 2: RSS + Whisper transcription
+Tier 2: RSS + Whisper transcription [RECOMMENDED]
   → Download MP3 from podcast RSS feed
   → Compress if >25 MB (ffmpeg)
-  → Transcribe via Groq Whisper API
+  → Transcribe via Groq Whisper API (free tier, ~10s/hr audio)
+  → Fast, free, and works for every podcast
       ↓
-Tier 3: Taddy API (commercial fallback)
-  → Requires TADDY_API_KEY
+Tier 3: Taddy API (commercial/premium)
+  → Requires TADDY_API_KEY ($75/mo+)
+  → Use for large-scale or production needs
 ```
 
 Search and batch features build on Tier 2:

--- a/skills/podcast-transcript-fetcher/README.md
+++ b/skills/podcast-transcript-fetcher/README.md
@@ -154,6 +154,31 @@ python scripts/get_transcript.py "20vc" --last 5
 python scripts/get_transcript.py --search "AI safety" --transcribe --transcribe-count 5
 ```
 
+### Parallel Transcription
+
+Speed up batch and pipeline jobs with the `--parallel N` flag:
+
+```bash
+# Set up multiple API keys (optional -- round-robin across workers)
+export GROQ_API_KEY="gsk_..."
+export GROQ_API_KEY_2="gsk_..."
+export GROQ_API_KEY_3="gsk_..."
+
+# Batch-transcribe 12 episodes with 3 parallel workers
+python scripts/get_transcript.py "Dwarkesh Podcast" --last 12 --parallel 3
+
+# Search pipeline with parallel transcription
+python scripts/get_transcript.py --search "AI safety" --transcribe --transcribe-count 10 --parallel 3
+```
+
+**How it works:**
+- Each worker independently downloads, compresses, and transcribes one episode
+- API keys are assigned round-robin across workers (`GROQ_API_KEY`, `GROQ_API_KEY_2`, ...)
+- Groq rate limit: ~30 req/min per key → 3 keys × 3 workers = ~90 req/min
+- Default `--parallel 1` maintains sequential backward-compatible behavior
+- Requires ffmpeg (for audio compression under Groq's 25 MB limit)
+- Output files are written independently with unique filenames (no contention)
+
 ## How It Works
 
 ```

--- a/skills/podcast-transcript-fetcher/SKILL.md
+++ b/skills/podcast-transcript-fetcher/SKILL.md
@@ -46,7 +46,7 @@ python scripts/get_transcript.py --list-podcasts
 
 ```bash
 # Core (always required)
-pip install requests
+pip install requests python-dotenv
 
 # Cloud transcription (recommended — fast, free tier)
 pip install groq
@@ -72,11 +72,11 @@ Tier 1 → Tier 2 → Tier 3
 ```
 
 **Tier 1: Free direct sources**
-- Lenny's: Clones `ChatPRD/lennys-podcast-transcripts` and searches by title
-- Dwarkesh: Fetches from PodScripts or scrapes episode pages
-- Cheeky Pint: Calls Spoken.md API (`SPOKENMD_API_KEY` or demo key `pt_demo`). **Note:** Spoken.md API is currently down (DNS lookup failing as of 2026-06); falls through to Tier 2.
-- 20VC: Uses YouTube transcript API or Libsyn RSS + Whisper
-- A16z: Fetches from PodScripts or Simplecast RSS + Whisper
+- Lenny's: GitHub archive at `ChatPRD/lennys-podcast-transcripts` (clone separately, then search by title). Falls through to Tier 2 if not cloned.
+- Dwarkesh: Checks for PodScripts or website transcript sections. Falls through to Tier 2.
+- Cheeky Pint: Calls Spoken.md API (`SPOKENMD_API_KEY` or demo key `pt_demo`). Currently down; falls through to Tier 2.
+- 20VC: Checks for existing YouTube transcript sources. Falls through to Tier 2.
+- A16z: Checks for PodScripts. Falls through to Tier 2.
 
 **Tier 2: RSS + Whisper transcription**
 - Downloads MP3 from podcast RSS feed
@@ -124,6 +124,31 @@ I have this transcript from [podcast]. Can you:
 | Pipeline with custom count | `get_transcript.py --search "scaling laws" --transcribe --transcribe-count 5` |
 | Filtered search pipeline | `get_transcript.py "A16z Podcast" --search "crypto" --transcribe` |
 
+### Parallel Transcription
+
+Speed up batch and pipeline jobs with parallel workers:
+
+```bash
+# Set up multiple API keys (optional — round-robin across workers)
+export GROQ_API_KEY="key-1"
+export GROQ_API_KEY_2="key-2"
+export GROQ_API_KEY_3="key-3"
+
+# Batch-transcribe 12 episodes with 3 parallel workers
+get_transcript.py "Dwarkesh Podcast" --last 12 --parallel 3
+
+# Search pipeline with parallel transcription
+get_transcript.py --search "AI" --transcribe --transcribe-count 10 --parallel 3
+```
+
+**How it works:**
+- Each worker downloads → compresses → transcribes one episode independently
+- API keys are assigned round-robin across workers using `GROQ_API_KEY`, `GROQ_API_KEY_2`, etc.
+- With 3 keys × 3 workers you can hit ~90 req/min (Groq's whisper limit is ~30 req/min/key)
+- Default is `--parallel 1` (sequential, backward-compatible)
+- Requires ffmpeg for audio compression (handles Groq's 25 MB file limit)
+- All workers share the same output directory; files are written independently (no conflicts)
+
 ### Output Structure
 
 Batch transcription saves to `output/` with per-podcast subdirectories:
@@ -166,7 +191,9 @@ The registry at `scripts/podcasts.json` maps each podcast to its RSS feeds, tran
 | "No transcript found" | Try `--method whisper` to force RSS+transcription |
 | RSS fetch fails | RSS feeds may change; check `scripts/podcasts.json` for current URLs |
 | Audio download slow | Large MP3s can take minutes on slow connections |
-| Groq rate limited | Wait or switch to local faster-whisper |
+| Groq rate limited | Wait, switch to local faster-whisper, or set multiple `GROQ_API_KEY_N` env vars + use `--parallel N` |
+| Parallel workers × keys | Each key handles ~30 req/min. With 3 keys: `--parallel 3` for ~90 req/min |
+| Taddy not returning transcripts | Some episodes lack transcripts; try `--method whisper` |
 | Taddy not returning transcripts | Some episodes lack transcripts; try `--method whisper` |
 | Podcast not in registry | Add it to `scripts/podcasts.json` |
 | Unicode error on Windows | Fixed: script auto-reconfigures stdout to UTF-8; saved files use UTF-8 encoding |

--- a/skills/podcast-transcript-fetcher/SKILL.md
+++ b/skills/podcast-transcript-fetcher/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: podcast-transcript-fetcher
-description: Use when fetching, searching, or analyzing transcripts from Lenny's Podcast, Dwarkesh Podcast, Cheeky Pint, 20VC, or A16z Podcast. Also use when asked to "get transcript", "find episode", "summarize podcast", or "search podcast content". Do not use for general web scraping or non-podcast audio transcription.
+description: Use when fetching, searching, or analyzing transcripts from Lenny's Podcast, Dwarkesh Podcast, Cheeky Pint, 20VC, or A16z Podcast. Tier 2 (RSS+Groq Whisper) is the recommended approach -- fast, free, and most reliable. Also use when asked to "get transcript", "find episode", "summarize podcast", or "search podcast content". Do not use for general web scraping or non-podcast audio transcription.
 author: farizanjum
-version: 1.0.0
+version: 1.1.0
 ---
 
 # Podcast Transcript Fetcher
 
-Fetch transcripts from 5 supported podcasts using a 3-tier approach: free direct sources, RSS+Whisper transcription, and Taddy API commercial fallback.
+Fetch transcripts from 5 supported podcasts. **Tier 2 (RSS+Groq Whisper) is the recommended approach** -- fast, free, and the most reliable across all podcasts. Tier 1 free sources are best-effort (limited availability). Tier 3 Taddy API is the premium/commercial option.
 
 ## Quick Reference
 
@@ -32,13 +32,13 @@ python scripts/get_transcript.py --list-podcasts
 
 ## Supported Podcasts
 
-| Podcast | Tier 1 (free) | Tier 2 (RSS+Whisper) | Tier 3 (Taddy) |
-|---------|--------------|----------------------|----------------|
+| Podcast | Tier 1 (best-effort) | Tier 2 RSS+Whisper [RECOMMENDED] | Tier 3 Taddy (premium) |
+|---------|---------------------|-----------------------------------|------------------------|
 | Lenny's Podcast | GitHub archive (269 transcripts) | ✅ Substack RSS | ✅ Covered |
-| Dwarkesh Podcast | Website scrape + PodScripts | ✅ Substack RSS | ✅ Covered |
-| Cheeky Pint | Spoken.md API (currently down) | ✅ Transistor.fm RSS | ✅ Covered |
-| 20VC | YouTube transcripts (199+) | ✅ Libsyn RSS | ✅ Covered |
-| A16z Podcast | PodScripts + website | ✅ Simplecast RSS | ✅ Covered |
+| Dwarkesh Podcast | Website scrape + Substack PDF | ✅ Substack RSS | ✅ Covered |
+| Cheeky Pint | (none) | ✅ Transistor.fm RSS | ✅ Covered |
+| 20VC | Substack PDF | ✅ Libsyn RSS | ✅ Covered |
+| A16z Podcast | Website scrape | ✅ Simplecast RSS | ✅ Covered |
 
 ## Implementation
 
@@ -46,7 +46,7 @@ python scripts/get_transcript.py --list-podcasts
 
 ```bash
 # Core (always required)
-pip install requests python-dotenv
+pip install requests
 
 # Cloud transcription (recommended — fast, free tier)
 pip install groq
@@ -64,26 +64,31 @@ export TADDY_API_KEY="your-key"  # Get at https://taddy.org
 
 ### 2. Get a Transcript
 
-The script auto-selects the best method:
+The script auto-selects the best method. **Tier 2 is the default recommendation:**
 
 ```
-Tier 1 → Tier 2 → Tier 3
-(free)  (Whisper) (Taddy API)
+Tier 1 → Tier 2 (RECOMMENDED) → Tier 3
+(best-effort)  (Whisper)  (Taddy API premium)
 ```
 
-**Tier 1: Free direct sources**
-- Lenny's: GitHub archive at `ChatPRD/lennys-podcast-transcripts` (clone separately, then search by title). Falls through to Tier 2 if not cloned.
-- Dwarkesh: Checks for PodScripts or website transcript sections. Falls through to Tier 2.
-- Cheeky Pint: Calls Spoken.md API (`SPOKENMD_API_KEY` or demo key `pt_demo`). Currently down; falls through to Tier 2.
-- 20VC: Checks for existing YouTube transcript sources. Falls through to Tier 2.
-- A16z: Checks for PodScripts. Falls through to Tier 2.
+**Tier 1: Free direct sources (best-effort, limited availability)**
+- Lenny's: Clones `ChatPRD/lennys-podcast-transcripts` and searches by title
+- Dwarkesh: Substack PDF scrape
+- 20VC: Substack PDF scrape
+- A16z: Website scrape
+- Cheeky Pint: No Tier 1 sources available
+- Note: Most free APIs (youtubetranscript.com, Spoken.md) are broken or paid. Tier 1 is unreliable -- prefer Tier 2.
 
-**Tier 2: RSS + Whisper transcription**
+**Tier 2: RSS + Whisper transcription [RECOMMENDED]**
 - Downloads MP3 from podcast RSS feed
-- Transcribes via Groq Whisper API (fast, free tier) or local faster-whisper
+- Compresses if >25 MB (ffmpeg)
+- Transcribes via Groq Whisper API (free tier, ~10s per hour of audio)
+- Fast, free, and works for every podcast in the registry
+- Default recommendation for all use cases
 
-**Tier 3: Taddy API**
-- Commercial fallback, requires `TADDY_API_KEY`
+**Tier 3: Taddy API (commercial/premium)**
+- Requires `TADDY_API_KEY` ($75/mo+)
+- Use for large-scale or production transcript needs
 - Covers all 5 podcasts with auto-transcription
 
 ### 3. Analyze with AI
@@ -107,8 +112,8 @@ I have this transcript from [podcast]. Can you:
 | Latest episode | `get_transcript.py "Lenny's Podcast" --latest` |
 | Specific episode by title | `get_transcript.py 20vc --episode "Sam Altman"` |
 | Episode by number | `get_transcript.py dwarkesh --episode 42` |
-| Force Whisper transcription | `get_transcript.py a16z --latest --method whisper` |
-| Force Taddy API | `get_transcript.py lennys --latest --method taddy` |
+| Force Whisper transcription (Tier 2, recommended) | `get_transcript.py a16z --latest --method whisper` |
+| Force Taddy API (premium) | `get_transcript.py lennys --latest --method taddy` |
 | Save to Markdown | `get_transcript.py cheeky-pint --latest --output episode.md` |
 | JSON output | `get_transcript.py dwarkesh --latest --json` |
 
@@ -123,31 +128,6 @@ I have this transcript from [podcast]. Can you:
 | Search + transcribe top matches | `get_transcript.py --search "AI safety" --transcribe` |
 | Pipeline with custom count | `get_transcript.py --search "scaling laws" --transcribe --transcribe-count 5` |
 | Filtered search pipeline | `get_transcript.py "A16z Podcast" --search "crypto" --transcribe` |
-
-### Parallel Transcription
-
-Speed up batch and pipeline jobs with parallel workers:
-
-```bash
-# Set up multiple API keys (optional — round-robin across workers)
-export GROQ_API_KEY="key-1"
-export GROQ_API_KEY_2="key-2"
-export GROQ_API_KEY_3="key-3"
-
-# Batch-transcribe 12 episodes with 3 parallel workers
-get_transcript.py "Dwarkesh Podcast" --last 12 --parallel 3
-
-# Search pipeline with parallel transcription
-get_transcript.py --search "AI" --transcribe --transcribe-count 10 --parallel 3
-```
-
-**How it works:**
-- Each worker downloads → compresses → transcribes one episode independently
-- API keys are assigned round-robin across workers using `GROQ_API_KEY`, `GROQ_API_KEY_2`, etc.
-- With 3 keys × 3 workers you can hit ~90 req/min (Groq's whisper limit is ~30 req/min/key)
-- Default is `--parallel 1` (sequential, backward-compatible)
-- Requires ffmpeg for audio compression (handles Groq's 25 MB file limit)
-- All workers share the same output directory; files are written independently (no conflicts)
 
 ### Output Structure
 
@@ -188,12 +168,10 @@ The registry at `scripts/podcasts.json` maps each podcast to its RSS feeds, tran
 
 | Problem | Solution |
 |---------|----------|
-| "No transcript found" | Try `--method whisper` to force RSS+transcription |
+| "No transcript found" | Tier 2 (RSS+Whisper) is the recommended approach. If auto mode fails, try `--method whisper` to force it. |
 | RSS fetch fails | RSS feeds may change; check `scripts/podcasts.json` for current URLs |
 | Audio download slow | Large MP3s can take minutes on slow connections |
-| Groq rate limited | Wait, switch to local faster-whisper, or set multiple `GROQ_API_KEY_N` env vars + use `--parallel N` |
-| Parallel workers × keys | Each key handles ~30 req/min. With 3 keys: `--parallel 3` for ~90 req/min |
-| Taddy not returning transcripts | Some episodes lack transcripts; try `--method whisper` |
+| Groq rate limited | Wait or switch to local faster-whisper |
 | Taddy not returning transcripts | Some episodes lack transcripts; try `--method whisper` |
 | Podcast not in registry | Add it to `scripts/podcasts.json` |
 | Unicode error on Windows | Fixed: script auto-reconfigures stdout to UTF-8; saved files use UTF-8 encoding |
@@ -210,6 +188,6 @@ The registry at `scripts/podcasts.json` maps each podcast to its RSS feeds, tran
 ## Common Mistakes
 
 - **Forgetting API keys**: Set `GROQ_API_KEY` in your env or `.env` file
-- **Assuming all episodes have free transcripts**: Only Lenny's has a large free archive; others may need Whisper
+- **Relying on Tier 1 free sources**: Most free APIs (youtubetranscript.com, Spoken.md) are broken or paid. Always fall back to Tier 2 (RSS+Whisper) which is the recommended method.
 - **Not cloning the Lenny's repo first**: The GitHub archive must be cloned locally for Tier 1 to work
 - **Using --method taddy without TADDY_API_KEY**: Falls through silently; set the key or use auto mode

--- a/skills/podcast-transcript-fetcher/SKILL.md
+++ b/skills/podcast-transcript-fetcher/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: podcast-transcript-fetcher
+description: Use when fetching, searching, or analyzing transcripts from Lenny's Podcast, Dwarkesh Podcast, Cheeky Pint, 20VC, or A16z Podcast. Also use when asked to "get transcript", "find episode", "summarize podcast", or "search podcast content". Do not use for general web scraping or non-podcast audio transcription.
+author: farizanjum
+version: 1.0.0
+---
+
+# Podcast Transcript Fetcher
+
+Fetch transcripts from 5 supported podcasts using a 3-tier approach: free direct sources, RSS+Whisper transcription, and Taddy API commercial fallback.
+
+## Quick Reference
+
+```bash
+# Get latest episode transcript (auto-detects best method)
+python scripts/get_transcript.py "Lenny's Podcast" --latest
+
+# Search by episode title or number
+python scripts/get_transcript.py 20vc --episode "Marc Andreessen"
+python scripts/get_transcript.py dwarkesh --episode 15
+
+# Force specific method
+python scripts/get_transcript.py "cheeky pint" --latest --method whisper
+python scripts/get_transcript.py a16z --latest --method taddy
+
+# Save to file
+python scripts/get_transcript.py lennys --latest --output transcript.md
+
+# List all supported podcasts
+python scripts/get_transcript.py --list-podcasts
+```
+
+## Supported Podcasts
+
+| Podcast | Tier 1 (free) | Tier 2 (RSS+Whisper) | Tier 3 (Taddy) |
+|---------|--------------|----------------------|----------------|
+| Lenny's Podcast | GitHub archive (269 transcripts) | ✅ Substack RSS | ✅ Covered |
+| Dwarkesh Podcast | Website scrape + PodScripts | ✅ Substack RSS | ✅ Covered |
+| Cheeky Pint | Spoken.md API (currently down) | ✅ Transistor.fm RSS | ✅ Covered |
+| 20VC | YouTube transcripts (199+) | ✅ Libsyn RSS | ✅ Covered |
+| A16z Podcast | PodScripts + website | ✅ Simplecast RSS | ✅ Covered |
+
+## Implementation
+
+### 1. Install Dependencies
+
+```bash
+# Core (always required)
+pip install requests
+
+# Cloud transcription (recommended — fast, free tier)
+pip install groq
+export GROQ_API_KEY="your-key"  # Get at https://console.groq.com
+
+# Local transcription (free, needs ~5GB RAM)
+pip install faster-whisper
+
+# Audio compression (for Groq's 25 MB limit — Windows: winget/scoop)
+#   winget install ffmpeg  or  scoop install ffmpeg
+
+# Taddy API (commercial, optional)
+export TADDY_API_KEY="your-key"  # Get at https://taddy.org
+```
+
+### 2. Get a Transcript
+
+The script auto-selects the best method:
+
+```
+Tier 1 → Tier 2 → Tier 3
+(free)  (Whisper) (Taddy API)
+```
+
+**Tier 1: Free direct sources**
+- Lenny's: Clones `ChatPRD/lennys-podcast-transcripts` and searches by title
+- Dwarkesh: Fetches from PodScripts or scrapes episode pages
+- Cheeky Pint: Calls Spoken.md API (`SPOKENMD_API_KEY` or demo key `pt_demo`). **Note:** Spoken.md API is currently down (DNS lookup failing as of 2026-06); falls through to Tier 2.
+- 20VC: Uses YouTube transcript API or Libsyn RSS + Whisper
+- A16z: Fetches from PodScripts or Simplecast RSS + Whisper
+
+**Tier 2: RSS + Whisper transcription**
+- Downloads MP3 from podcast RSS feed
+- Transcribes via Groq Whisper API (fast, free tier) or local faster-whisper
+
+**Tier 3: Taddy API**
+- Commercial fallback, requires `TADDY_API_KEY`
+- Covers all 5 podcasts with auto-transcription
+
+### 3. Analyze with AI
+
+Once you have a transcript, pipe it to the agent for analysis:
+
+```markdown
+I have this transcript from [podcast]. Can you:
+1. Summarize the key arguments
+2. Extract 3 actionable insights
+3. Identify any controversial claims
+4. Compare with [other podcast] on the same topic
+```
+
+## Supported Workflows
+
+### Single Episode
+
+| Scenario | Command |
+|----------|---------|
+| Latest episode | `get_transcript.py "Lenny's Podcast" --latest` |
+| Specific episode by title | `get_transcript.py 20vc --episode "Sam Altman"` |
+| Episode by number | `get_transcript.py dwarkesh --episode 42` |
+| Force Whisper transcription | `get_transcript.py a16z --latest --method whisper` |
+| Force Taddy API | `get_transcript.py lennys --latest --method taddy` |
+| Save to Markdown | `get_transcript.py cheeky-pint --latest --output episode.md` |
+| JSON output | `get_transcript.py dwarkesh --latest --json` |
+
+### Cross-Podcast Search & Batch
+
+| Scenario | Command |
+|----------|---------|
+| Search all podcasts by keyword | `get_transcript.py --search "Marc Andreessen"` |
+| Search by guest name | `get_transcript.py --guest "Sam Altman"` |
+| Search within one podcast | `get_transcript.py "Lenny's Podcast" --search "vibe coding"` |
+| Batch-transcribe last N episodes | `get_transcript.py "Dwarkesh Podcast" --last 5` |
+| Search + transcribe top matches | `get_transcript.py --search "AI safety" --transcribe` |
+| Pipeline with custom count | `get_transcript.py --search "scaling laws" --transcribe --transcribe-count 5` |
+| Filtered search pipeline | `get_transcript.py "A16z Podcast" --search "crypto" --transcribe` |
+
+### Output Structure
+
+Batch transcription saves to `output/` with per-podcast subdirectories:
+
+```
+output/dwarkesh-podcast/Dwarkesh Podcast_2024-01-15_agi-is-still-30-years-away.md
+output/20vc/20 Minutes VC (20VC)_2024-03-10_funding-round-analysis.md
+```
+
+Each file includes a YAML frontmatter header:
+```yaml
+---
+podcast: Dwarkesh Podcast
+episode: AGI is still 30 years away
+date: 2024-01-15
+url: https://...
+source: whisper
+---
+```
+
+## Podcast Registry
+
+The registry at `scripts/podcasts.json` maps each podcast to its RSS feeds, transcript sources, and API endpoints. To add new podcasts:
+
+```json
+{
+  "id": "new-podcast",
+  "name": "New Podcast",
+  "rss": "https://example.com/feed.xml",
+  "transcript_sources": {
+    "primary": {"type": "website_scrape", "url": "https://example.com"}
+  }
+}
+```
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| "No transcript found" | Try `--method whisper` to force RSS+transcription |
+| RSS fetch fails | RSS feeds may change; check `scripts/podcasts.json` for current URLs |
+| Audio download slow | Large MP3s can take minutes on slow connections |
+| Groq rate limited | Wait or switch to local faster-whisper |
+| Taddy not returning transcripts | Some episodes lack transcripts; try `--method whisper` |
+| Podcast not in registry | Add it to `scripts/podcasts.json` |
+| Unicode error on Windows | Fixed: script auto-reconfigures stdout to UTF-8; saved files use UTF-8 encoding |
+| Audio > 25 MB for Groq | Install ffmpeg: `winget install ffmpeg` (Windows) or `brew install ffmpeg` (macOS) |
+
+## RSS Feed Status (as of 2026-06)
+
+| Podcast | Old Feed (broken) | Current Feed |
+|---------|------------------|--------------|
+| Cheeky Pint | `feeds.transistor.fm/the-cheeky-pint` (404) | `feeds.transistor.fm/cheeky-pint-with-john-collison` |
+| 20VC | `feeds.simplecast.com/3GxrMqOd` (404) | `feeds.libsyn.com/61840/rss` |
+| A16z | `feeds.simplecast.com/0cJfpoz2` (404) | `feeds.simplecast.com/JGE3yC0V` |
+
+## Common Mistakes
+
+- **Forgetting API keys**: Set `GROQ_API_KEY` in your env or `.env` file
+- **Assuming all episodes have free transcripts**: Only Lenny's has a large free archive; others may need Whisper
+- **Not cloning the Lenny's repo first**: The GitHub archive must be cloned locally for Tier 1 to work
+- **Using --method taddy without TADDY_API_KEY**: Falls through silently; set the key or use auto mode

--- a/skills/podcast-transcript-fetcher/SKILL.md
+++ b/skills/podcast-transcript-fetcher/SKILL.md
@@ -77,7 +77,7 @@ Tier 1 → Tier 2 (RECOMMENDED) → Tier 3
 - 20VC: Substack PDF scrape
 - A16z: Website scrape
 - Cheeky Pint: No Tier 1 sources available
-- Note: Most free APIs (youtubetranscript.com, Spoken.md) are broken or paid. Tier 1 is unreliable -- prefer Tier 2.
+- Note: Tier 1 sources are best-effort and limited. Tier 2 (RSS+Whisper) is the recommended approach.
 
 **Tier 2: RSS + Whisper transcription [RECOMMENDED]**
 - Downloads MP3 from podcast RSS feed
@@ -188,6 +188,6 @@ The registry at `scripts/podcasts.json` maps each podcast to its RSS feeds, tran
 ## Common Mistakes
 
 - **Forgetting API keys**: Set `GROQ_API_KEY` in your env or `.env` file
-- **Relying on Tier 1 free sources**: Most free APIs (youtubetranscript.com, Spoken.md) are broken or paid. Always fall back to Tier 2 (RSS+Whisper) which is the recommended method.
+- **Relying on Tier 1 free sources**: Tier 1 is best-effort and limited. Always fall back to Tier 2 (RSS+Whisper) which is the recommended method.
 - **Not cloning the Lenny's repo first**: The GitHub archive must be cloned locally for Tier 1 to work
 - **Using --method taddy without TADDY_API_KEY**: Falls through silently; set the key or use auto mode

--- a/skills/podcast-transcript-fetcher/package.json
+++ b/skills/podcast-transcript-fetcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "podcast-transcript-fetcher",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Fetch, search, and batch-transcribe transcripts from 5 top podcasts (Lenny's, Dwarkesh, Cheeky Pint, 20VC, A16z) using a 3-tier approach",
   "category": "Research"
 }

--- a/skills/podcast-transcript-fetcher/package.json
+++ b/skills/podcast-transcript-fetcher/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "podcast-transcript-fetcher",
+  "version": "1.0.0",
+  "description": "Fetch, search, and batch-transcribe transcripts from 5 top podcasts (Lenny's, Dwarkesh, Cheeky Pint, 20VC, A16z) using a 3-tier approach",
+  "category": "Research"
+}

--- a/skills/podcast-transcript-fetcher/references/podcasts.md
+++ b/skills/podcast-transcript-fetcher/references/podcasts.md
@@ -80,12 +80,6 @@ Detailed reference for each podcast's transcript availability and how to access 
 - Transcribe with local Whisper or Groq API
 - See `get_transcript.py --method whisper`
 
-**Tier 2 — Spoken.md API (currently down)**
-- API endpoint: `https://api.spoken.md/v1` (DNS lookup failing as of 2026-06)
-- Demo key: `pt_demo`
-- Environment variable: `SPOKENMD_API_KEY` (override demo key)
-- Returns JSON with full transcript + speaker labels when online
-
 **Note:** The RSS feed was renamed from `the-cheeky-pint` to `cheeky-pint-with-john-collison` (Transistor.fm migration). The old feed URL returns 404.
 
 ---

--- a/skills/podcast-transcript-fetcher/references/podcasts.md
+++ b/skills/podcast-transcript-fetcher/references/podcasts.md
@@ -109,7 +109,7 @@ Detailed reference for each podcast's transcript availability and how to access 
 **Tier 2 — YouTube Transcripts (free, 199+ episodes)**
 - Existing skill: `sboghossian/20vc-claude-skill` — 199 YouTube transcripts
 - GitHub: https://github.com/sboghossian/20vc-claude-skill
-- Extracted via `youtube-transcript-api`
+
 - Covers many recent episodes
 
 **Tier 3 — Substack PDFs**
@@ -147,7 +147,7 @@ Detailed reference for each podcast's transcript availability and how to access 
 
 ---
 
-## Taddy API (Commercial, Tier 3)
+## Taddy API (Commercial, Tier 2)
 
 For any podcast not covered by free sources above:
 
@@ -173,7 +173,7 @@ query {
 
 ---
 
-## Whisper Transcription (Tier 2 Fallback)
+## Whisper Transcription (Tier 3 Fallback)
 
 ### Local (faster-whisper)
 ```bash
@@ -190,7 +190,7 @@ for seg in segments:
 ### Cloud (Groq API — generous free tier)
 ```bash
 pip install groq
-# Set GROQ_API_KEY (and optional GROQ_API_KEY_2, GROQ_API_KEY_3 for parallel)
+# Set GROQ_API_KEY
 python -c "
 from groq import Groq
 client = Groq()
@@ -201,12 +201,3 @@ with open('episode.mp3', 'rb') as f:
     print(transcription.text)
 "
 ```
-
-## Parallel Transcription
-
-The `--parallel N` flag (default: 1) speed up batch and pipeline jobs via `concurrent.futures.ThreadPoolExecutor`:
-
-- **Multiple API keys**: Set `GROQ_API_KEY`, `GROQ_API_KEY_2`, `GROQ_API_KEY_3`, etc. Keys are assigned round-robin across workers.
-- **Rate limit**: Groq's whisper endpoint is ~30 req/min per key. With 3 keys, `--parallel 3` can hit ~90 req/min.
-- **Per-worker**: Each worker independently downloads the MP3, compresses it (ffmpeg), transcribes it, and saves the file.
-- **Safety**: Temp directories are cleaned per-worker; file writes use unique filenames (no contention).

--- a/skills/podcast-transcript-fetcher/references/podcasts.md
+++ b/skills/podcast-transcript-fetcher/references/podcasts.md
@@ -147,7 +147,7 @@ Detailed reference for each podcast's transcript availability and how to access 
 
 ---
 
-## Taddy API (Commercial, Tier 2)
+## Taddy API (Commercial, Tier 3)
 
 For any podcast not covered by free sources above:
 
@@ -173,7 +173,7 @@ query {
 
 ---
 
-## Whisper Transcription (Tier 3 Fallback)
+## Whisper Transcription (Tier 2 Fallback)
 
 ### Local (faster-whisper)
 ```bash
@@ -190,7 +190,7 @@ for seg in segments:
 ### Cloud (Groq API — generous free tier)
 ```bash
 pip install groq
-# Set GROQ_API_KEY
+# Set GROQ_API_KEY (and optional GROQ_API_KEY_2, GROQ_API_KEY_3 for parallel)
 python -c "
 from groq import Groq
 client = Groq()
@@ -201,3 +201,12 @@ with open('episode.mp3', 'rb') as f:
     print(transcription.text)
 "
 ```
+
+## Parallel Transcription
+
+The `--parallel N` flag (default: 1) speed up batch and pipeline jobs via `concurrent.futures.ThreadPoolExecutor`:
+
+- **Multiple API keys**: Set `GROQ_API_KEY`, `GROQ_API_KEY_2`, `GROQ_API_KEY_3`, etc. Keys are assigned round-robin across workers.
+- **Rate limit**: Groq's whisper endpoint is ~30 req/min per key. With 3 keys, `--parallel 3` can hit ~90 req/min.
+- **Per-worker**: Each worker independently downloads the MP3, compresses it (ffmpeg), transcribes it, and saves the file.
+- **Safety**: Temp directories are cleaned per-worker; file writes use unique filenames (no contention).

--- a/skills/podcast-transcript-fetcher/references/podcasts.md
+++ b/skills/podcast-transcript-fetcher/references/podcasts.md
@@ -1,0 +1,203 @@
+# Podcast Transcript Sources
+
+Detailed reference for each podcast's transcript availability and how to access them.
+
+---
+
+## Lenny's Podcast
+
+| Detail | Value |
+|--------|-------|
+| **Host** | Lenny Rachitsky |
+| **Website** | https://www.lennyspodcast.com |
+| **RSS Feed** | `https://api.substack.com/feed/podcast/10845.rss` |
+| **Substack** | https://lennyspodcast.substack.com |
+| **Episode archive** | Full back-catalog on Substack |
+
+### Transcript Sources (in priority order)
+
+**Tier 1 — GitHub Archive (free, 269+ transcripts)**
+- Repo: `ChatPRD/lennys-podcast-transcripts`
+- 269 pre-transcribed episodes in Markdown format
+- Clone: `git clone https://github.com/ChatPRD/lennys-podcast-transcripts.git`
+- Episodes are named by title, searchable via grep
+- Best source for older/medium episodes
+
+**Tier 2 — Dropbox Official Archive**
+- Linked from Substack episode pages
+- Contains official transcripts uploaded by Lenny's team
+- Accessible via shared Dropbox links (no login required for reading)
+
+**Tier 3 — RSS Transcript Tag**
+- Some episodes include `<podcast:transcript>` in RSS XML
+- Usually links to Substack page with inline transcript
+- Format: `text/html` or `text/plain`
+
+**Existing Tools**
+- `akshayvkt/lenny-mcp`: MCP server searching 284 transcripts via FlexSearch
+- `mpnikhil/lenny-rag-mcp`: Hierarchical RAG over 299 transcripts in ChromaDB
+
+---
+
+## Dwarkesh Podcast
+
+| Detail | Value |
+|--------|-------|
+| **Host** | Dwarkesh Patel |
+| **Website** | https://www.dwarkesh.com |
+| **RSS Feed** | `https://api.substack.com/feed/podcast/69345.rss` |
+| **Substack** | https://dwarkesh.substack.com |
+
+### Transcript Sources
+
+**Tier 1 — Website Scrape (free)**
+- Individual episode pages on dwarkesh.com contain full transcripts
+- Layout: Episode page → scroll down for transcript section
+- URL pattern: `https://www.dwarkesh.com/p/{episode-slug}`
+
+**Tier 2 — PodScripts**
+- Indexed on PodScripts.co
+- URL: https://podscripts.co/podcasts/dwarkesh-podcast
+
+**Tier 3 — GitHub Gists**
+- Some transcripts posted as gists
+- Search: `git.io/dwarkesh-transcript` or GitHub search
+
+---
+
+## The Cheeky Pint
+
+| Detail | Value |
+|--------|-------|
+| **Website** | https://thecheekypint.com |
+| **RSS Feed** | `https://feeds.transistor.fm/cheeky-pint-with-john-collison` |
+| **Hosting** | Transistor.fm |
+
+### Transcript Sources
+
+**Tier 1 — RSS + Whisper (default)**
+- Download MP3 from RSS feed
+- Transcribe with local Whisper or Groq API
+- See `get_transcript.py --method whisper`
+
+**Tier 2 — Spoken.md API (currently down)**
+- API endpoint: `https://api.spoken.md/v1` (DNS lookup failing as of 2026-06)
+- Demo key: `pt_demo`
+- Environment variable: `SPOKENMD_API_KEY` (override demo key)
+- Returns JSON with full transcript + speaker labels when online
+
+**Note:** The RSS feed was renamed from `the-cheeky-pint` to `cheeky-pint-with-john-collison` (Transistor.fm migration). The old feed URL returns 404.
+
+---
+
+## 20 Minutes VC (20VC)
+
+| Detail | Value |
+|--------|-------|
+| **Host** | Harry Stebbings |
+| **Website** | https://20vc.com |
+| **RSS Feed** | `https://feeds.libsyn.com/61840/rss` |
+| **Hosting** | Libsyn (migrated from Simplecast) |
+
+### Transcript Sources
+
+**Tier 1 — RSS + Whisper (default)**
+- Hosted on Libsyn (12 MB feed, 1476+ episodes)
+- Download MP3 from RSS feed, transcribe with Whisper
+- See `get_transcript.py --method whisper`
+
+**Tier 2 — YouTube Transcripts (free, 199+ episodes)**
+- Existing skill: `sboghossian/20vc-claude-skill` — 199 YouTube transcripts
+- GitHub: https://github.com/sboghossian/20vc-claude-skill
+- Extracted via `youtube-transcript-api`
+- Covers many recent episodes
+
+**Tier 3 — Substack PDFs**
+- Some episodes published on Substack with PDF transcripts
+- URL: https://20vc.substack.com
+
+**Note:** 20VC migrated from Simplecast to Libsyn. The old Simplecast RSS (`feeds.simplecast.com/3GxrMqOd`) returns 404 (`NoSuchKey`).
+
+---
+
+## A16z Podcast
+
+| Detail | Value |
+|--------|-------|
+| **Website** | https://a16z.com/podcasts |
+| **RSS Feed** | `https://feeds.simplecast.com/JGE3yC0V` |
+| **Hosting** | Simplecast (relocated feed) |
+
+### Transcript Sources
+
+**Tier 1 — RSS + Whisper (default)**
+- Download MP3 from Simplecast RSS (8.9 MB feed, 1000 episodes)
+- Transcribe with Whisper (local or Groq)
+
+**Tier 2 — PodScripts (free)**
+- URL: https://podscripts.co/podcasts/a16z-podcast
+- Indexed and searchable
+
+**Tier 3 — Website Scrape**
+- a16z.com/podcasts has per-episode pages
+- Some episodes include transcript sections
+- Format varies by episode
+
+**Note:** The a16z Podcast (now "The a16z Show") RSS feed UUID changed. Old feed at `feeds.simplecast.com/0cJfpoz2` returns 404 (`NoSuchKey`). Current live feed at `feeds.simplecast.com/JGE3yC0V`.
+
+---
+
+## Taddy API (Commercial, Tier 2)
+
+For any podcast not covered by free sources above:
+
+| Detail | Value |
+|--------|-------|
+| **Endpoint** | `https://api.taddy.org` |
+| **Auth** | `X-API-Key` header with `TADDY_API_KEY` env var |
+| **Coverage** | 4M+ podcasts, 200M episodes |
+| **Transcripts** | Auto-transcribes top 5,000 podcasts (includes all 5 targets) |
+| **On-demand** | ~10s per 1hr audio for rest |
+| **Pricing** | Free: 500 req/mo. Pro: $75/mo (100k req + 100 transcripts) |
+
+### GraphQL Query Example
+```graphql
+query {
+  getEpisode(uuid: "...") {
+    name
+    transcript
+    audioUrl
+  }
+}
+```
+
+---
+
+## Whisper Transcription (Tier 3 Fallback)
+
+### Local (faster-whisper)
+```bash
+pip install faster-whisper
+python -c "
+from faster_whisper import WhisperModel
+model = WhisperModel('large-v3', device='cpu', compute_type='int8')
+segments, _ = model.transcribe('episode.mp3')
+for seg in segments:
+    print(f'[{seg.start:.1f}s -> {seg.end:.1f}s] {seg.text}')
+"
+```
+
+### Cloud (Groq API — generous free tier)
+```bash
+pip install groq
+# Set GROQ_API_KEY
+python -c "
+from groq import Groq
+client = Groq()
+with open('episode.mp3', 'rb') as f:
+    transcription = client.audio.transcriptions.create(
+        file=f, model='whisper-large-v3'
+    )
+    print(transcription.text)
+"
+```

--- a/skills/podcast-transcript-fetcher/scripts/get_transcript.py
+++ b/skills/podcast-transcript-fetcher/scripts/get_transcript.py
@@ -15,6 +15,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import concurrent.futures
 import json
 import os
 import re
@@ -327,7 +328,9 @@ def find_episode(episodes: list[dict[str, Any]], query: str | None):
         if query_lower in ep["guid"].lower():
             return ep
     
-    return episodes[0]  # fallback to latest
+    # No match found
+    print(f"   [ERROR] Could not find episode matching '{query}'")
+    return None
 
 
 # -- RSS URL helper -------------------------------------------------
@@ -392,10 +395,73 @@ def _print_search_results(
     print()
 
 
+def _transcribe_job(
+    job_type: str,
+    podcast_name: str,
+    ep: dict[str, Any],
+    index: int,
+    total: int,
+    api_keys: list[str],
+) -> bool:
+    """Process a single episode end-to-end: download, compress, transcribe, save.
+    
+    Args:
+        job_type: Label for logging (e.g. "Batch" or "Search").
+        podcast_name: Display name of the podcast.
+        ep: Episode dict with title, pub_date, link, audio_url.
+        index: 0-based index for round-robin key selection and filename.
+        total: Total count for progress display.
+        api_keys: List of GROQ API keys for round-robin.
+    
+    Returns:
+        True if the episode was successfully transcribed and saved, False otherwise.
+    """
+    ep_title = ep.get("title") or f"Episode {index + 1}"
+    pub_date = ep.get("pub_date") or ""
+    episode_url = ep.get("link") or ep.get("guid") or ""
+    audio_url = ep.get("audio_url") or ""
+
+    if not audio_url:
+        print(f"   [{job_type}] [SKIP] {ep_title} - no audio URL")
+        return False
+
+    output_path = _auto_filename(podcast_name, ep_title, pub_date, index + 1)
+    if output_path.exists():
+        print(f"   [{job_type}] [SKIP] Already exists: {output_path.name}")
+        return True  # Count as success since it's already done
+
+    tmp_dir = Path(tempfile.mkdtemp(prefix="podcast_"))
+    audio_path = tmp_dir / "episode.mp3"
+    try:
+        if not download_audio(audio_url, audio_path):
+            print(f"   [{job_type}] [FAIL] Download failed for {ep_title}")
+            return False
+
+        audio_path = _compress_audio(audio_path)
+
+        key = _pick_key(api_keys, index)
+        transcript = _transcribe_groq(audio_path, api_key=key)
+        if transcript:
+            _write_transcript_with_header(
+                transcript, podcast_name, ep_title, pub_date, episode_url, output_path
+            )
+            print(f"   [{job_type}] [OK] Transcribed: {ep_title}")
+            return True
+        else:
+            print(f"   [{job_type}] [FAIL] Transcription returned empty for {ep_title}")
+            return False
+    except Exception as e:
+        print(f"   [{job_type}] [ERROR] {ep_title}: {e}")
+        return False
+    finally:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+
+
 def batch_transcribe(
     podcast: dict[str, Any],
     count: int,
     episodes: list[dict[str, Any]],
+    parallel: int = 1,
 ):
     """Transcribe the last N episodes of a podcast and save to output/."""
     name = podcast["name"]
@@ -406,59 +472,40 @@ def batch_transcribe(
 
     print(f"\n{'='*60}")
     print(f"   Batch transcribing {total} episodes of {name}")
+    if parallel > 1:
+        print(f"   Parallel workers: {parallel}")
     print(f"{'='*60}\n")
 
-    # Import groq here since it's only needed for this path
+    api_keys = _get_api_keys()
+    if not api_keys:
+        print("   [ERROR] No GROQ_API_KEY found. Set GROQ_API_KEY in your environment.")
+        print("   Fall back to local Whisper by installing faster-whisper.")
+        return
+
+    # Reverse: newest episodes first
+    tasks = list(range(total - 1, -1, -1))
+
     success_count = 0
+    future_map: dict[concurrent.futures.Future[bool], int] = {}
 
-    for i in range(total - 1, -1, -1):
-        ep = episodes[i]
-        ep_title = ep.get("title") or f"Episode {i+1}"
-        pub_date = ep.get("pub_date") or ""
-        episode_url = ep.get("url") or ep.get("guid") or ""
-        audio_url = ep.get("audio_url") or ""
-        if not audio_url:
-            print(f"   [SKIP] {ep_title} - no audio URL")
-            continue
-
-        print(f"\n   --- Episode {total - i}/{total}: {ep_title} ---")
-        print(f"       Date: {pub_date}")
-        print(f"       Audio: {audio_url}")
-
-        output_path = _auto_filename(name, ep_title, pub_date, total - i)
-        if output_path.exists():
-            print(f"   [SKIP] Already exists: {output_path.name}")
-            success_count += 1
-            continue
-
-        # Download
-        tmp_dir = Path(tempfile.mkdtemp(prefix="podcast_"))
-        audio_path = tmp_dir / "episode.mp3"
-        try:
-            ok = download_audio(audio_url, audio_path)
-            if not ok:
-                print(f"   [FAIL] Download failed for {ep_title}")
-                shutil.rmtree(tmp_dir, ignore_errors=True)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=parallel) as pool:
+        for i in tasks:
+            ep = episodes[i]
+            audio_url = ep.get("audio_url") or ""
+            if not audio_url:
                 continue
+            future = pool.submit(
+                _transcribe_job, "Batch", name, ep, total - i, total, api_keys
+            )
+            future_map[future] = total - i
 
-            # Compress if needed
-            audio_path = _compress_audio(audio_path)
-
-            # Transcribe
-            print(f"   [Whisper] Transcribing...")
-            transcript = _transcribe_groq(audio_path)
-            if transcript:
-                _write_transcript_with_header(
-                    transcript, name, ep_title, pub_date, episode_url, output_path
-                )
-                success_count += 1
-                print(f"   [OK] Transcribed: {ep_title}")
-            else:
-                print(f"   [FAIL] Transcription returned empty for {ep_title}")
-        except Exception as e:
-            print(f"   [ERROR] {ep_title}: {e}")
-        finally:
-            shutil.rmtree(tmp_dir, ignore_errors=True)
+        for future in concurrent.futures.as_completed(future_map):
+            idx = future_map[future]
+            try:
+                if future.result():
+                    success_count += 1
+            except Exception as e:
+                print(f"   [Batch] [ERROR] Episode {idx}: {e}")
 
     print(f"\n{'='*60}")
     print(f"   Done. {success_count}/{total} episodes transcribed successfully.")
@@ -473,6 +520,7 @@ def _run_search_pipeline(
     podcast_name: str | None,
     auto_transcribe: bool,
     transcribe_count: int,
+    parallel: int = 1,
 ):
     """Search across podcasts, optionally transcribe top results."""
     term = query or guest or ""
@@ -511,7 +559,7 @@ def _run_search_pipeline(
     seen_guids = set()
     picked = []
     for pname, ep in flat:
-        guid = ep.get("guid") or ep.get("url") or ep.get("title", "")
+        guid = ep.get("guid") or ep.get("link") or ep.get("title", "")
         if guid not in seen_guids:
             seen_guids.add(guid)
             picked.append((pname, ep))
@@ -524,47 +572,32 @@ def _run_search_pipeline(
 
     print(f"\n   Pipeline: searching for '{term}' → transcribing top {len(picked)} episode(s)\n")
 
+    api_keys = _get_api_keys()
+    if not api_keys:
+        print("   [ERROR] No GROQ_API_KEY found. Set GROQ_API_KEY in your environment.")
+        print("   Fall back to local Whisper by installing faster-whisper.")
+        return
+
     success_count = 0
+    future_map: dict[concurrent.futures.Future[bool], tuple[int, str]] = {}
 
-    for pname, ep in picked:
-        ep_title = ep.get("title") or "Untitled"
-        pub_date = ep.get("pub_date") or ""
-        episode_url = ep.get("url") or ep.get("guid") or ""
-        audio_url = ep.get("audio_url") or ""
-        if not audio_url:
-            print(f"   [SKIP] {ep_title} - no audio URL")
-            continue
-
-        print(f"\n   --- {pname}: {ep_title} ---")
-        output_path = _auto_filename(pname, ep_title, pub_date, len(picked))
-        if output_path.exists():
-            print(f"   [SKIP] Already exists: {output_path.name}")
-            success_count += 1
-            continue
-
-        tmp_dir = Path(tempfile.mkdtemp(prefix="podcast_"))
-        audio_path = tmp_dir / "episode.mp3"
-        try:
-            ok = download_audio(audio_url, audio_path)
-            if not ok:
-                print(f"   [FAIL] Download failed")
-                shutil.rmtree(tmp_dir, ignore_errors=True)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=parallel) as pool:
+        for idx, (pname, ep) in enumerate(picked):
+            audio_url = ep.get("audio_url") or ""
+            if not audio_url:
                 continue
+            future = pool.submit(
+                _transcribe_job, "Pipeline", pname, ep, idx + 1, len(picked), api_keys
+            )
+            future_map[future] = (idx + 1, pname)
 
-            audio_path = _compress_audio(audio_path)
-
-            transcript = _transcribe_groq(audio_path)
-            if transcript:
-                _write_transcript_with_header(
-                    transcript, pname, ep_title, pub_date, episode_url, output_path
-                )
-                success_count += 1
-            else:
-                print(f"   [FAIL] Transcription empty")
-        except Exception as e:
-            print(f"   [ERROR] {ep_title}: {e}")
-        finally:
-            shutil.rmtree(tmp_dir, ignore_errors=True)
+        for future in concurrent.futures.as_completed(future_map):
+            seq, pname = future_map[future]
+            try:
+                if future.result():
+                    success_count += 1
+            except Exception as e:
+                print(f"   [Pipeline] [ERROR] ({seq}) {pname}: {e}")
 
     print(f"\n   Pipeline done. {success_count}/{len(picked)} transcribed.\n")
 
@@ -602,10 +635,8 @@ def try_tier1(podcast: dict[str, Any], episode_query: str | None = None) -> str 
         stype = source.get("type", "")
         
         if stype == "github_archive" and "repo" in source:
-            print(f"   -> Checking GitHub archive: {source['repo']}")
-            # We can't clone here (no git token), but we can query raw content
-            # Suggest the user to clone separately or use existing archive
-            return None  # Let the agent handle this via skill instructions
+            print(f"   -> GitHub archive: {source['repo']} (clone separately for Tier 1)")
+            # GitHub archive requires local clone; drop through to try other sources
         
         elif stype == "spokenmd_api":
             api_key = os.environ.get("SPOKENMD_API_KEY", source.get("demo_key", "pt_demo"))
@@ -659,22 +690,25 @@ def try_tier2(podcast: dict[str, Any], episode_query: str | None = None) -> str 
     if not download_audio(audio_url, audio_path):
         return None
     
-    # Check if Groq API key is available
-    groq_key = os.environ.get("GROQ_API_KEY")
-    if groq_key:
-        return _transcribe_groq(audio_path)
-    
-    # Check if faster-whisper is available
     try:
-        return _transcribe_local(audio_path)
-    except ImportError:
-        print("   [WARN]  No transcription backend available.")
-        print("   Install one:")
-        print("      Cloud (recommended): pip install groq && export GROQ_API_KEY=...")
-        print("      Local:              pip install faster-whisper")
-        print(f"   Audio saved at: {audio_path}")
-        print(f"   Audio URL: {audio_url}")
-        return None
+        # Check if Groq API key is available
+        groq_key = os.environ.get("GROQ_API_KEY")
+        if groq_key:
+            return _transcribe_groq(audio_path)
+
+        # Check if faster-whisper is available
+        try:
+            return _transcribe_local(audio_path)
+        except ImportError:
+            print("   [WARN]  No transcription backend available.")
+            print("   Install one:")
+            print("      Cloud (recommended): pip install groq && export GROQ_API_KEY=...")
+            print("      Local:              pip install faster-whisper")
+            print(f"   Audio saved at: {audio_path}")
+            print(f"   Audio URL: {audio_url}")
+            return None
+    finally:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
 
 
 def _compress_audio(path: Path, max_mb: int = 22) -> Path:
@@ -718,10 +752,52 @@ def _compress_audio(path: Path, max_mb: int = 22) -> Path:
     return path
 
 
-def _transcribe_groq(audio_path: Path) -> str | None:
-    """Transcribe audio using Groq's Whisper API."""
-    groq_key = os.environ.get("GROQ_API_KEY")
+def _get_api_keys() -> list[str]:
+    """Collect all available GROQ API keys from environment variables.
+    
+    Reads GROQ_API_KEY (base), GROQ_API_KEY_2, GROQ_API_KEY_3, etc.
+    Returns a list of unique non-empty keys. If none found, returns [].
+    """
+    keys: list[str] = []
+    seen: set[str] = set()
+    
+    # Base key always first
+    base = os.environ.get("GROQ_API_KEY", "").strip()
+    if base and base not in seen:
+        keys.append(base)
+        seen.add(base)
+    
+    # Scan for numbered keys
+    idx = 2
+    while True:
+        val = os.environ.get(f"GROQ_API_KEY_{idx}", "").strip()
+        if not val:
+            break
+        if val not in seen:
+            keys.append(val)
+            seen.add(val)
+        idx += 1
+    
+    return keys
+
+
+def _pick_key(api_keys: list[str], index: int) -> str | None:
+    """Round-robin pick an API key from the list, or return None if empty."""
+    if not api_keys:
+        return None
+    return api_keys[index % len(api_keys)]
+
+
+def _transcribe_groq(audio_path: Path, api_key: str | None = None) -> str | None:
+    """Transcribe audio using Groq's Whisper API.
+    
+    Args:
+        audio_path: Path to the audio file.
+        api_key: Optional explicit API key. If None, reads from GROQ_API_KEY env var.
+    """
+    groq_key = api_key or os.environ.get("GROQ_API_KEY")
     if not groq_key:
+        print("   [ERROR] GROQ_API_KEY is not set. Export GROQ_API_KEY or use local Whisper (pip install faster-whisper).")
         return None
     
     print(f"   [Cloud] Transcribing via Groq Whisper API...")
@@ -938,6 +1014,8 @@ Examples:
                         help="Max episodes to transcribe in search pipeline (default: 3)")
     parser.add_argument("--method", "-m", choices=["auto", "tier1", "whisper", "taddy"], default="auto",
                         help="Transcription method (default: auto = try all tiers)")
+    parser.add_argument("--parallel", type=int, default=1, metavar="N",
+                        help="Parallel transcription workers (default: 1). Set >1 with multiple GROQ_API_KEY_N env vars.")
     parser.add_argument("--output", "-o", default=None, help="Save transcript to file")
     parser.add_argument("--list-podcasts", action="store_true", help="List available podcasts")
     parser.add_argument("--json", action="store_true", help="Output as JSON")
@@ -951,10 +1029,15 @@ Examples:
         term = args.search or args.guest or ""
         # If podcast name is given, filter to that podcast
         podcast_filter = args.podcast if args.podcast else None
+        if podcast_filter:
+            found = find_podcast(podcast_filter, registry)
+            if found:
+                podcast_filter = found["name"]
         
         auto_transcribe = args.transcribe
         _run_search_pipeline(registry, args.search, args.guest,
-                             podcast_filter, auto_transcribe, args.transcribe_count)
+                             podcast_filter, auto_transcribe, args.transcribe_count,
+                             parallel=args.parallel)
         return
     
     # -- Feature: Batch transcribe last N (requires podcast + --last) -
@@ -975,7 +1058,7 @@ Examples:
         if not episodes:
             print(f"[ERROR] No episodes found via RSS for {podcast['name']}")
             sys.exit(1)
-        batch_transcribe(podcast, args.last, episodes)
+        batch_transcribe(podcast, args.last, episodes, parallel=args.parallel)
         return
     
     # -- Feature: List podcasts --------------------------------------

--- a/skills/podcast-transcript-fetcher/scripts/get_transcript.py
+++ b/skills/podcast-transcript-fetcher/scripts/get_transcript.py
@@ -1076,11 +1076,11 @@ def try_tier2(podcast: dict[str, Any], episode_query: str | None = None) -> str 
     # Download audio to temp file
     tmp_dir = Path(tempfile.mkdtemp(prefix="podcast_"))
     audio_path = tmp_dir / "episode.mp3"
-    
-    if not download_audio(audio_url, audio_path):
-        return None
-    
+
     try:
+        if not download_audio(audio_url, audio_path):
+            return None
+
         # Check if Groq API key is available
         groq_key = os.environ.get("GROQ_API_KEY")
         if groq_key:

--- a/skills/podcast-transcript-fetcher/scripts/get_transcript.py
+++ b/skills/podcast-transcript-fetcher/scripts/get_transcript.py
@@ -361,13 +361,25 @@ def _parse_pub_date(ep: dict[str, Any]) -> datetime:
     raw = (ep.get("pub_date") or "").strip()
     if not raw:
         return datetime(1970, 1, 1, tzinfo=timezone.utc)
+    # Try RFC 2822 (standard RSS pubDate format, e.g. "Mon, 01 Jan 2024 00:00:00 GMT")
     try:
         dt = parsedate_to_datetime(raw)
-        if dt.tzinfo is None:
-            dt = dt.replace(tzinfo=timezone.utc)
-        return dt
+        if dt is not None:
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return dt
     except (ValueError, TypeError, OverflowError):
-        return datetime(1970, 1, 1, tzinfo=timezone.utc)
+        pass
+    # Try ISO 8601 (e.g. "2024-01-01" or "2024-01-01T00:00:00Z")
+    for fmt in ("%Y-%m-%d", "%Y-%m-%dT%H:%M:%S%z", "%Y-%m-%dT%H:%M:%SZ", "%Y-%m-%dT%H:%M:%S"):
+        try:
+            dt = datetime.strptime(raw, fmt)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return dt
+        except ValueError:
+            continue
+    return datetime(1970, 1, 1, tzinfo=timezone.utc)
 
 
 def sort_episodes_newest_first(episodes: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -522,22 +534,18 @@ def batch_transcribe(
         print("   Fall back to local Whisper by installing faster-whisper.")
         return
 
-    # Process from oldest-of-the-selected to newest (reverse display order)
-    indices = list(range(total - 1, -1, -1))
-
     success_count = 0
     future_map: dict[concurrent.futures.Future[bool], int] = {}
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=parallel) as pool:
-        for i in indices:
-            ep = selected[i]
+        for display_index, ep in enumerate(reversed(selected), start=1):
             audio_url = ep.get("audio_url") or ""
             if not audio_url:
                 continue
             future = pool.submit(
-                _transcribe_job, "Batch", name, ep, total - i, total, api_keys
+                _transcribe_job, "Batch", name, ep, display_index, total, api_keys
             )
-            future_map[future] = total - i
+            future_map[future] = display_index
 
         for future in concurrent.futures.as_completed(future_map):
             idx = future_map[future]

--- a/skills/podcast-transcript-fetcher/scripts/get_transcript.py
+++ b/skills/podcast-transcript-fetcher/scripts/get_transcript.py
@@ -1098,11 +1098,16 @@ def try_tier2(podcast: dict[str, Any], episode_query: str | None = None) -> str 
         try:
             return _transcribe_local(audio_path)
         except ImportError:
+            # Save audio to a persistent location before tmp_dir is cleaned up
+            persistent_dir = OUTPUT_DIR / _slugify(podcast["name"]) / "audio"
+            persistent_dir.mkdir(parents=True, exist_ok=True)
+            persistent_audio = persistent_dir / audio_path.name
+            shutil.copy2(audio_path, persistent_audio)
             print("   [WARN]  No transcription backend available.")
             print("   Install one:")
             print("      Cloud (recommended): pip install groq && export GROQ_API_KEY=...")
             print("      Local:              pip install faster-whisper")
-            print(f"   Audio saved at: {audio_path}")
+            print(f"   Audio saved at: {persistent_audio}")
             print(f"   Audio URL: {audio_url}")
             return None
     finally:

--- a/skills/podcast-transcript-fetcher/scripts/get_transcript.py
+++ b/skills/podcast-transcript-fetcher/scripts/get_transcript.py
@@ -28,6 +28,8 @@ import urllib.error
 import urllib.parse
 import xml.etree.ElementTree as ET
 import html
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
 from pathlib import Path
 from typing import Any
 
@@ -68,9 +70,13 @@ def load_registry():
         return json.load(f)
 
 
-def find_podcast(query: str, registry: dict[str, Any]):
+def find_podcast(query: str | None, registry: dict[str, Any]):
     """Fuzzy-match a podcast name/slug against the registry."""
+    if not query:
+        return None
     query = query.strip().lower()
+    if not query:
+        return None
     podcasts = registry.get("podcasts", [])
     
     # Exact match on id, slug, or name
@@ -87,14 +93,18 @@ def find_podcast(query: str, registry: dict[str, Any]):
     
     # Token overlap ("lenny" -> "Lenny's Podcast", "20vc" -> "20 Minutes VC")
     query_tokens = set(re.split(r"[\s'-]+", query))
+    query_tokens.discard("")
+    if not query_tokens:
+        return None
     scored = []
     for p in podcasts:
         name_tokens = set(re.split(r"[\s'-]+", p["name"].lower()))
+        name_tokens.discard("")
         overlap = len(query_tokens & name_tokens)
         if overlap > 0:
             scored.append((overlap, p))
     if scored:
-        scored.sort(reverse=True)
+        scored.sort(reverse=True, key=lambda x: x[0])
         return scored[0][1]
     
     return None
@@ -346,6 +356,25 @@ def _get_rss_urls(podcast: dict[str, Any]) -> list[str]:
     return [rss] if rss else []
 
 
+def _parse_pub_date(ep: dict[str, Any]) -> datetime:
+    """Parse an episode's pub_date into a datetime (timezone-aware). Returns epoch for unparseable dates."""
+    raw = (ep.get("pub_date") or "").strip()
+    if not raw:
+        return datetime(1970, 1, 1, tzinfo=timezone.utc)
+    try:
+        dt = parsedate_to_datetime(raw)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt
+    except (ValueError, TypeError, OverflowError):
+        return datetime(1970, 1, 1, tzinfo=timezone.utc)
+
+
+def sort_episodes_newest_first(episodes: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Sort episode list by publication date descending (newest first)."""
+    return sorted(episodes, key=_parse_pub_date, reverse=True)
+
+
 # -- Search & Batch Transcription ------------------------------------
 
 def search_episodes(
@@ -465,12 +494,21 @@ def batch_transcribe(
     episodes: list[dict[str, Any]],
     parallel: int = 1,
 ):
-    """Transcribe the last N episodes of a podcast and save to output/."""
+    """Transcribe the most recent N episodes of a podcast and save to output/.
+    
+    Episodes are sorted by publication date (newest first) to ensure consistent
+    behaviour regardless of the RSS feed ordering.
+    """
     name = podcast["name"]
-    total = min(count, len(episodes))
+    # Sort newest-first so we always pick the right N
+    sorted_eps = sort_episodes_newest_first(episodes)
+    total = min(count, len(sorted_eps))
     if total == 0:
         print(f"   No episodes available for {name}.")
         return
+
+    # Pick the most recent N
+    selected = sorted_eps[:total]
 
     print(f"\n{'='*60}")
     print(f"   Batch transcribing {total} episodes of {name}")
@@ -484,15 +522,15 @@ def batch_transcribe(
         print("   Fall back to local Whisper by installing faster-whisper.")
         return
 
-    # Reverse: newest episodes first
-    tasks = list(range(total - 1, -1, -1))
+    # Process from oldest-of-the-selected to newest (reverse display order)
+    indices = list(range(total - 1, -1, -1))
 
     success_count = 0
     future_map: dict[concurrent.futures.Future[bool], int] = {}
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=parallel) as pool:
-        for i in tasks:
-            ep = episodes[i]
+        for i in indices:
+            ep = selected[i]
             audio_url = ep.get("audio_url") or ""
             if not audio_url:
                 continue
@@ -562,14 +600,21 @@ def _run_search_pipeline(
     for pname, eps in all_results:
         for ep in eps:
             flat.append((pname, ep))
-    # Deduplicate and limit
-    seen_guids = set()
+    # Deduplicate by BOTH guid and link independently
+    seen_guids: set[str] = set()
+    seen_links: set[str] = set()
     picked = []
     for pname, ep in flat:
-        guid = ep.get("guid") or ep.get("link") or ep.get("title", "")
-        if guid not in seen_guids:
+        guid = (ep.get("guid") or "").strip()
+        link = (ep.get("link") or "").strip()
+        # Skip if we have already seen this guid or this link
+        if (guid and guid in seen_guids) or (link and link in seen_links):
+            continue
+        if guid:
             seen_guids.add(guid)
-            picked.append((pname, ep))
+        if link:
+            seen_links.add(link)
+        picked.append((pname, ep))
         if len(picked) >= transcribe_count:
             break
 

--- a/skills/podcast-transcript-fetcher/scripts/get_transcript.py
+++ b/skills/podcast-transcript-fetcher/scripts/get_transcript.py
@@ -1,0 +1,1030 @@
+#!/usr/bin/env python3
+"""
+Podcast Transcript Fetcher -- 3-tier CLI for getting podcast transcripts.
+
+Tier 1: Direct free sources (GitHub archives, APIs, website scrapes)
+Tier 2: RSS audio download + Whisper transcription (local or Groq cloud)
+Tier 3: Taddy API (commercial, requires TADDY_API_KEY)
+
+Usage:
+    python get_transcript.py <podcast> [--episode <episode>] [--method <method>]
+    python get_transcript.py <podcast> --latest
+    python get_transcript.py --list-podcasts
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import sys
+import tempfile
+import time
+import urllib.request
+import urllib.error
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import Any
+
+# Auto-load .env from project root or parent directories
+try:
+    from dotenv import load_dotenv
+
+    _script_dir = Path(__file__).resolve().parent
+    _project_root = _script_dir.parent
+    load_dotenv(_project_root / ".env")
+except ImportError:
+    pass
+
+# -- Fix Windows console encoding ------------------------------------
+# Prevent UnicodeEncodeError when printing transcripts with non-ASCII
+# characters (e.g. Dwarkesh transcripts with accented characters) on
+# Windows consoles that default to cp1252.
+if sys.platform == "win32" and sys.stdout.encoding and sys.stdout.encoding.lower() in ("cp1252", "ansi"):
+    sys.stdout.reconfigure(encoding="utf-8")
+
+# -- Paths ---------------------------------------------------------
+
+SCRIPT_DIR = Path(__file__).parent
+PROJECT_DIR = SCRIPT_DIR.parent
+REGISTRY_PATH = SCRIPT_DIR / "podcasts.json"
+CACHE_DIR = SCRIPT_DIR / ".rss_cache"
+OUTPUT_DIR = PROJECT_DIR / "output"
+CACHE_TTL_SEC = 3600  # 1 hour
+
+# -- Registry --------------------------------------------------------
+
+def load_registry():
+    """Load the podcast registry JSON."""
+    if not REGISTRY_PATH.exists():
+        print(f"[ERROR] Registry not found at {REGISTRY_PATH}", file=sys.stderr)
+        sys.exit(1)
+    with open(REGISTRY_PATH) as f:
+        return json.load(f)
+
+
+def find_podcast(query: str, registry: dict[str, Any]):
+    """Fuzzy-match a podcast name/slug against the registry."""
+    query = query.strip().lower()
+    podcasts = registry.get("podcasts", [])
+    
+    # Exact match on id, slug, or name
+    for p in podcasts:
+        if query in [p["id"].lower(), p["slug"].lower(), p["name"].lower()]:
+            return p
+    
+    # Substring match
+    for p in podcasts:
+        if query in p["name"].lower():
+            return p
+        if query in p["slug"].lower():
+            return p
+    
+    # Token overlap ("lenny" -> "Lenny's Podcast", "20vc" -> "20 Minutes VC")
+    query_tokens = set(re.split(r"[\s'-]+", query))
+    scored = []
+    for p in podcasts:
+        name_tokens = set(re.split(r"[\s'-]+", p["name"].lower()))
+        overlap = len(query_tokens & name_tokens)
+        if overlap > 0:
+            scored.append((overlap, p))
+    if scored:
+        scored.sort(reverse=True)
+        return scored[0][1]
+    
+    return None
+
+
+def list_podcasts(registry: dict[str, Any], as_json: bool = False):
+    """Print all registered podcasts."""
+    if as_json:
+        print(json.dumps(registry, indent=2))
+        return
+    print(f"\n== Registered Podcasts ({len(registry['podcasts'])}):")
+    print(f"   {'-' * 60}")
+    for p in registry["podcasts"]:
+        sources = list(p["transcript_sources"].keys())
+        print(f"   {p['name']:30s}  ({', '.join(sources)})")
+    print()
+
+# -- RSS Caching Layer ----------------------------------------------
+
+def _cache_path(url: str) -> Path:
+    """Return the cache file path for a given RSS URL."""
+    safe_name = re.sub(r"[^a-zA-Z0-9]+", "_", url.split("//")[-1])
+    safe_name = safe_name.strip("_")[:120]
+    return CACHE_DIR / f"{safe_name}.json"
+
+
+def _load_cached_rss(url: str) -> list[dict[str, Any]] | None:
+    """Return cached episodes if cache is still fresh (< TTL)."""
+    path = _cache_path(url)
+    if not path.exists():
+        return None
+    age = time.time() - path.stat().st_mtime
+    if age > CACHE_TTL_SEC:
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        print(f"   [CACHE] Using cached RSS ({int(age)}s old): {len(data)} episodes")
+        return data
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def _save_cached_rss(url: str, episodes: list[dict[str, Any]]):
+    """Save parsed RSS episodes to cache."""
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    path = _cache_path(url)
+    path.write_text(json.dumps(episodes, indent=2, default=str), encoding="utf-8")
+
+
+def fetch_rss_cached(url: str) -> list[dict[str, Any]]:
+    """Fetch and parse RSS with caching. Returns list of episode dicts."""
+    cached = _load_cached_rss(url)
+    if cached is not None:
+        return cached
+    episodes = fetch_rss(url)
+    if episodes:
+        _save_cached_rss(url, episodes)
+    return episodes
+
+
+# -- Output Helpers -------------------------------------------------
+
+def _slugify(text: str) -> str:
+    """Convert text to a safe filesystem slug."""
+    text = text.lower().strip()
+    text = re.sub(r"[^\w\s-]", "", text)
+    text = re.sub(r"[-\s]+", "-", text)
+    return text[:80].rstrip("-")
+
+
+def _auto_filename(
+    podcast_name: str,
+    episode_title: str,
+    pub_date: str,
+    index: int,
+) -> Path:
+    """Generate output path: output/{podcast_slug}/PodcastName_Date_Title.md"""
+    podcast_slug = _slugify(podcast_name)
+    date_part = pub_date[:10] if pub_date else "unknown-date"
+    title_slug = _slugify(episode_title)[:60]
+    filename = f"{podcast_name}_{date_part}_{title_slug}.md"
+    # Collision-safe: if filename is too long, use index-based name
+    if len(filename) > 200:
+        filename = f"{podcast_name}_{date_part}_{index:03d}.md"
+    out_dir = OUTPUT_DIR / podcast_slug
+    out_dir.mkdir(parents=True, exist_ok=True)
+    return out_dir / filename
+
+
+def _write_transcript_with_header(
+    transcript_text: str,
+    podcast_name: str,
+    episode_title: str,
+    pub_date: str,
+    episode_url: str,
+    output_path: Path,
+):
+    """Write a transcript file with YAML frontmatter metadata header."""
+    header = (
+        "---\n"
+        f"podcast: {podcast_name}\n"
+        f"episode: {episode_title}\n"
+        f"date: {pub_date}\n"
+        f"url: {episode_url}\n"
+        f"source: whisper\n"
+        "---\n\n"
+    )
+    output_path.write_text(header + transcript_text, encoding="utf-8")
+    print(f"   [SAVED] {output_path}")
+
+
+# -- RSS Parsing -----------------------------------------------------
+
+def fetch_rss(url: str):
+    """Fetch and parse an RSS feed. Returns list of episode dicts."""
+    print(f"   [RSS] Fetching: {url}")
+    raw = None
+    
+    # Try requests first (handles redirects, better headers)
+    try:
+        import requests
+        headers = {
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+                          "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+            "Accept": "application/rss+xml, application/xml, text/xml, */*",
+        }
+        resp = requests.get(url, headers=headers, timeout=30)
+        if resp.status_code == 200:
+            raw = resp.content
+    except ImportError:
+        pass  # requests not installed, fall back to urllib
+    except Exception as e:
+        print(f"   [WARN] requests fetch failed: {e}, trying urllib...")
+    
+    # Fall back to urllib
+    if raw is None:
+        try:
+            req = urllib.request.Request(
+                url,
+                headers={"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"},
+            )
+            resp = urllib.request.urlopen(req, timeout=30)
+            raw = resp.read()
+        except Exception as e:
+            print(f"   [ERROR] RSS fetch failed: {e}", file=sys.stderr)
+            return []
+    
+    episodes = []
+    try:
+        root = ET.fromstring(raw)
+    except ET.ParseError as e:
+        print(f"   [ERROR] RSS parse failed: {e}", file=sys.stderr)
+        return []
+    
+    # Handle RSS 2.0 and Atom
+    ns = {"itunes": "http://www.itunes.com/dtds/podcast-1.0.dtd"}
+    for item in root.iter("item"):
+        ep = {
+            "title": item.findtext("title", ""),
+            "pub_date": item.findtext("pubDate", ""),
+            "link": item.findtext("link", ""),
+            "description": item.findtext("description", ""),
+            "audio_url": None,
+            "guid": item.findtext("guid", ""),
+        }
+        # Audio enclosure
+        enclosure = item.find("enclosure")
+        if enclosure is not None:
+            ep["audio_url"] = enclosure.get("url")
+        episodes.append(ep)
+    
+    # Try RSS 2.0 with namespaces (Simplecast, Transistor)
+    if not episodes:
+        for item in root.iter("item"):
+            ep = {
+                "title": item.findtext("title", ""),
+                "pub_date": item.findtext("pubDate", ""),
+                "link": item.findtext("link", ""),
+                "description": item.findtext("description", ""),
+                "audio_url": None,
+                "guid": item.findtext("guid", ""),
+            }
+            enclosure = item.find("enclosure")
+            if enclosure is not None:
+                ep["audio_url"] = enclosure.get("url")
+            episodes.append(ep)
+    
+    # Try JSON Feed / namespace-based RSS
+    if not episodes:
+        for item in root.iter("{http://www.w3.org/2005/Atom}entry"):
+            ep = {
+                "title": item.findtext("{http://www.w3.org/2005/Atom}title", ""),
+                "pub_date": item.findtext("{http://www.w3.org/2005/Atom}updated", ""),
+                "link": "",
+                "description": item.findtext("{http://www.w3.org/2005/Atom}summary", ""),
+                "audio_url": None,
+                "guid": "",
+            }
+            for link in item.iter("{http://www.w3.org/2005/Atom}link"):
+                rel = link.get("rel", "")
+                if rel in ("enclosure", "") and link.get("href"):
+                    ep["audio_url"] = link.get("href")
+            episodes.append(ep)
+    
+    return episodes
+
+
+def find_episode(episodes: list[dict[str, Any]], query: str | None):
+    """Find an episode by query: 'latest', number, title substring, or None (-> latest)."""
+    if not episodes:
+        return None
+    
+    if not query or query == "latest":
+        return episodes[0]  # RSS is reverse-chronological
+    
+    # Try number match ("15" or "episode 15")
+    query_lower = query.lower().strip()
+    num_match = re.search(r"(\d+)", query_lower)
+    
+    if num_match:
+        num = num_match.group(1)
+        for ep in episodes:
+            if f"episode {num}" in ep["title"].lower() or f"#{num}" in ep["title"]:
+                return ep
+    
+    # Substring search in title
+    for ep in episodes:
+        if query_lower in ep["title"].lower():
+            return ep
+    
+    # GUID search
+    for ep in episodes:
+        if query_lower in ep["guid"].lower():
+            return ep
+    
+    return episodes[0]  # fallback to latest
+
+
+# -- RSS URL helper -------------------------------------------------
+
+def _get_rss_urls(podcast: dict[str, Any]) -> list[str]:
+    """Extract RSS URL(s) from a podcast dict (supports 'rss' string or 'rss_urls' list)."""
+    if "rss_urls" in podcast:
+        urls = podcast["rss_urls"]
+        return urls if isinstance(urls, list) else [urls]
+    rss = podcast.get("rss")
+    return [rss] if rss else []
+
+
+# -- Search & Batch Transcription ------------------------------------
+
+def search_episodes(
+    episodes: list[dict[str, Any]],
+    query: str,
+) -> list[dict[str, Any]]:
+    """Search episodes by keyword in title and description. Returns scored matches."""
+    query_lower = query.lower()
+    scored = []
+    for ep in episodes:
+        title = (ep.get("title") or "").lower()
+        desc = (ep.get("description") or "").lower()
+        score = 0
+        if query_lower in title:
+            score += 10
+        if query_lower in desc:
+            score += 3
+        if score > 0:
+            scored.append((score, ep))
+    scored.sort(reverse=True, key=lambda x: x[0])
+    return [ep for _, ep in scored]
+
+
+def find_by_guest(
+    episodes: list[dict[str, Any]],
+    guest_name: str,
+) -> list[dict[str, Any]]:
+    """Search episodes by guest name (looks in title and description)."""
+    return search_episodes(episodes, guest_name)
+
+
+def _print_search_results(
+    results: list[tuple[str, list[dict[str, Any]]]],
+):
+    """Print search results grouped by podcast."""
+    total = sum(len(eps) for _, eps in results)
+    if total == 0:
+        print("   No matching episodes found.")
+        return
+    print(f"\n== Found {total} matching episode(s):\n")
+    for podcast_name, eps in results:
+        print(f"   [{podcast_name}] ({len(eps)} matches):")
+        for ep in eps[:10]:  # show top 10 per podcast
+            title = (ep.get("title") or "Untitled")[:90]
+            date = (ep.get("pub_date") or "?")[:10]
+            print(f"      {date}  {title}")
+        if len(eps) > 10:
+            print(f"      ... and {len(eps) - 10} more")
+    print()
+
+
+def batch_transcribe(
+    podcast: dict[str, Any],
+    count: int,
+    episodes: list[dict[str, Any]],
+):
+    """Transcribe the last N episodes of a podcast and save to output/."""
+    name = podcast["name"]
+    total = min(count, len(episodes))
+    if total == 0:
+        print(f"   No episodes available for {name}.")
+        return
+
+    print(f"\n{'='*60}")
+    print(f"   Batch transcribing {total} episodes of {name}")
+    print(f"{'='*60}\n")
+
+    # Import groq here since it's only needed for this path
+    success_count = 0
+
+    for i in range(total - 1, -1, -1):
+        ep = episodes[i]
+        ep_title = ep.get("title") or f"Episode {i+1}"
+        pub_date = ep.get("pub_date") or ""
+        episode_url = ep.get("url") or ep.get("guid") or ""
+        audio_url = ep.get("audio_url") or ""
+        if not audio_url:
+            print(f"   [SKIP] {ep_title} - no audio URL")
+            continue
+
+        print(f"\n   --- Episode {total - i}/{total}: {ep_title} ---")
+        print(f"       Date: {pub_date}")
+        print(f"       Audio: {audio_url}")
+
+        output_path = _auto_filename(name, ep_title, pub_date, total - i)
+        if output_path.exists():
+            print(f"   [SKIP] Already exists: {output_path.name}")
+            success_count += 1
+            continue
+
+        # Download
+        tmp_dir = Path(tempfile.mkdtemp(prefix="podcast_"))
+        audio_path = tmp_dir / "episode.mp3"
+        try:
+            ok = download_audio(audio_url, audio_path)
+            if not ok:
+                print(f"   [FAIL] Download failed for {ep_title}")
+                shutil.rmtree(tmp_dir, ignore_errors=True)
+                continue
+
+            # Compress if needed
+            audio_path = _compress_audio(audio_path)
+
+            # Transcribe
+            print(f"   [Whisper] Transcribing...")
+            transcript = _transcribe_groq(audio_path)
+            if transcript:
+                _write_transcript_with_header(
+                    transcript, name, ep_title, pub_date, episode_url, output_path
+                )
+                success_count += 1
+                print(f"   [OK] Transcribed: {ep_title}")
+            else:
+                print(f"   [FAIL] Transcription returned empty for {ep_title}")
+        except Exception as e:
+            print(f"   [ERROR] {ep_title}: {e}")
+        finally:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+
+    print(f"\n{'='*60}")
+    print(f"   Done. {success_count}/{total} episodes transcribed successfully.")
+    print(f"   Output: {OUTPUT_DIR / _slugify(name)}/")
+    print(f"{'='*60}\n")
+
+
+def _run_search_pipeline(
+    registry: dict[str, Any],
+    query: str | None,
+    guest: str | None,
+    podcast_name: str | None,
+    auto_transcribe: bool,
+    transcribe_count: int,
+):
+    """Search across podcasts, optionally transcribe top results."""
+    term = query or guest or ""
+    if not term:
+        print("   No search term provided.")
+        return
+
+    all_results: list[tuple[str, list[dict[str, Any]]]] = []
+
+    for p in registry["podcasts"]:
+        name = p["name"]
+        if podcast_name and podcast_name.lower() not in name.lower():
+            continue
+        rss_urls = _get_rss_urls(p)
+        if not rss_urls:
+            continue
+
+        episodes = fetch_rss_cached(rss_urls[0])
+        if not episodes:
+            continue
+
+        matches = search_episodes(episodes, term)
+        if matches:
+            all_results.append((name, matches))
+    if not auto_transcribe:
+        _print_search_results(all_results)
+        return
+
+    # Auto-transcribe: pick top matches across all podcasts (up to transcribe_count)
+    # Flatten and rank
+    flat = []
+    for pname, eps in all_results:
+        for ep in eps:
+            flat.append((pname, ep))
+    # Deduplicate and limit
+    seen_guids = set()
+    picked = []
+    for pname, ep in flat:
+        guid = ep.get("guid") or ep.get("url") or ep.get("title", "")
+        if guid not in seen_guids:
+            seen_guids.add(guid)
+            picked.append((pname, ep))
+        if len(picked) >= transcribe_count:
+            break
+
+    if not picked:
+        print("   No episodes found to transcribe.")
+        return
+
+    print(f"\n   Pipeline: searching for '{term}' → transcribing top {len(picked)} episode(s)\n")
+
+    success_count = 0
+
+    for pname, ep in picked:
+        ep_title = ep.get("title") or "Untitled"
+        pub_date = ep.get("pub_date") or ""
+        episode_url = ep.get("url") or ep.get("guid") or ""
+        audio_url = ep.get("audio_url") or ""
+        if not audio_url:
+            print(f"   [SKIP] {ep_title} - no audio URL")
+            continue
+
+        print(f"\n   --- {pname}: {ep_title} ---")
+        output_path = _auto_filename(pname, ep_title, pub_date, len(picked))
+        if output_path.exists():
+            print(f"   [SKIP] Already exists: {output_path.name}")
+            success_count += 1
+            continue
+
+        tmp_dir = Path(tempfile.mkdtemp(prefix="podcast_"))
+        audio_path = tmp_dir / "episode.mp3"
+        try:
+            ok = download_audio(audio_url, audio_path)
+            if not ok:
+                print(f"   [FAIL] Download failed")
+                shutil.rmtree(tmp_dir, ignore_errors=True)
+                continue
+
+            audio_path = _compress_audio(audio_path)
+
+            transcript = _transcribe_groq(audio_path)
+            if transcript:
+                _write_transcript_with_header(
+                    transcript, pname, ep_title, pub_date, episode_url, output_path
+                )
+                success_count += 1
+            else:
+                print(f"   [FAIL] Transcription empty")
+        except Exception as e:
+            print(f"   [ERROR] {ep_title}: {e}")
+        finally:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+
+    print(f"\n   Pipeline done. {success_count}/{len(picked)} transcribed.\n")
+
+
+# -- Audio Download --------------------------------------------------
+
+def download_audio(url: str, output_path: Path) -> bool:
+    """Download an audio file from URL to output_path. Returns success."""
+    print(f"   [DL] Downloading audio...")
+    try:
+        req = urllib.request.Request(
+            url, headers={"User-Agent": "Mozilla/5.0 (podcast-transcript-skill/1.0)"}
+        )
+        with urllib.request.urlopen(req, timeout=300) as resp:
+            with open(output_path, "wb") as f:
+                while chunk := resp.read(8192):
+                    f.write(chunk)
+        size_mb = output_path.stat().st_size / (1024 * 1024)
+        print(f"   [OK] Downloaded ({size_mb:.1f} MB)")
+        return True
+    except Exception as e:
+        print(f"   [ERROR] Download failed: {e}", file=sys.stderr)
+        return False
+
+
+# -- Tier 1: Direct Sources ------------------------------------------
+
+def try_tier1(podcast: dict[str, Any], episode_query: str | None = None) -> str | None:
+    """Try free direct sources for the podcast. Returns transcript or None."""
+    sources = podcast.get("transcript_sources", {})
+    print(f"\n   [Tier 1] Checking free sources for {podcast['name']}...")
+    
+    # 1a: GitHub archive (Lenny's Podcast)
+    for source_key, source in sources.items():
+        stype = source.get("type", "")
+        
+        if stype == "github_archive" and "repo" in source:
+            print(f"   -> Checking GitHub archive: {source['repo']}")
+            # We can't clone here (no git token), but we can query raw content
+            # Suggest the user to clone separately or use existing archive
+            return None  # Let the agent handle this via skill instructions
+        
+        elif stype == "spokenmd_api":
+            api_key = os.environ.get("SPOKENMD_API_KEY", source.get("demo_key", "pt_demo"))
+            print(f"   -> Querying Spoken.md API...")
+            try:
+                req = urllib.request.Request(
+                    f"{source['api_endpoint']}/transcripts",
+                    headers={"Authorization": f"Bearer {api_key}"},
+                )
+                resp = urllib.request.urlopen(req, timeout=15)
+                data = json.loads(resp.read())
+                if data and "transcript" in data:
+                    return data["transcript"]
+            except Exception as e:
+                print(f"   [WARN]  Spoken.md API failed: {e}")
+    
+    return None
+
+
+# -- Tier 2: RSS + Whisper -------------------------------------------
+
+def try_tier2(podcast: dict[str, Any], episode_query: str | None = None) -> str | None:
+    """Download audio from RSS and transcribe via Whisper/Groq."""
+    rss_url = podcast.get("rss")
+    if not rss_url:
+        print("   [WARN]  No RSS feed configured for this podcast")
+        return None
+    
+    print(f"\n   [Tier 2] RSS -> Audio -> Transcription")
+    episodes = fetch_rss(rss_url)
+    if not episodes:
+        print("   [ERROR] No episodes found in RSS feed")
+        return None
+    
+    ep = find_episode(episodes, episode_query)
+    if not ep:
+        print("   [ERROR] Could not find matching episode")
+        return None
+    
+    print(f"   Episode: {ep['title']}")
+    
+    audio_url = ep.get("audio_url")
+    if not audio_url:
+        print("   [ERROR] No audio URL in episode")
+        return None
+    
+    # Download audio to temp file
+    tmp_dir = Path(tempfile.mkdtemp(prefix="podcast_"))
+    audio_path = tmp_dir / "episode.mp3"
+    
+    if not download_audio(audio_url, audio_path):
+        return None
+    
+    # Check if Groq API key is available
+    groq_key = os.environ.get("GROQ_API_KEY")
+    if groq_key:
+        return _transcribe_groq(audio_path)
+    
+    # Check if faster-whisper is available
+    try:
+        return _transcribe_local(audio_path)
+    except ImportError:
+        print("   [WARN]  No transcription backend available.")
+        print("   Install one:")
+        print("      Cloud (recommended): pip install groq && export GROQ_API_KEY=...")
+        print("      Local:              pip install faster-whisper")
+        print(f"   Audio saved at: {audio_path}")
+        print(f"   Audio URL: {audio_url}")
+        return None
+
+
+def _compress_audio(path: Path, max_mb: int = 22) -> Path:
+    """Compress audio to stay under Groq's 25 MB limit using ffmpeg."""
+    size_mb = path.stat().st_size / (1024 * 1024)
+    if size_mb <= max_mb:
+        return path
+    
+    compressed = path.with_suffix(".mp3").parent / f"{path.stem}_compressed.mp3"
+    print(f"   [COMPRESS] {size_mb:.0f} MB -> target <{max_mb} MB")
+    
+    # Try ffmpeg (best quality)
+    try:
+        import subprocess
+        bitrate = "32k"
+        subprocess.run(
+            ["ffmpeg", "-y", "-i", str(path), "-ac", "1", "-ar", "16000",
+             "-b:a", bitrate, str(compressed)],
+            capture_output=True, timeout=120, check=True,
+        )
+        print(f"   [OK] Compressed ({compressed.stat().st_size / 1024 / 1024:.0f} MB)")
+        return compressed
+    except Exception:
+        pass  # fall through
+    
+    # Fall back to pydub if available
+    try:
+        from pydub import AudioSegment
+        audio = AudioSegment.from_file(path)
+        audio = audio.set_channels(1).set_frame_rate(16000)
+        audio.export(compressed, format="mp3", bitrate="32k")
+        print(f"   [OK] Compressed via pydub ({compressed.stat().st_size / 1024 / 1024:.0f} MB)")
+        return compressed
+    except ImportError:
+        pass
+    
+    # No compression tool available
+    print(f"   [WARN] No compression tool found (ffmpeg/pydub).")
+    print(f"   [WARN] File is {size_mb:.0f} MB; Groq limit is 25 MB.")
+    print(f"   [WARN] Install ffmpeg or pydub for auto-compression.")
+    return path
+
+
+def _transcribe_groq(audio_path: Path) -> str | None:
+    """Transcribe audio using Groq's Whisper API."""
+    groq_key = os.environ.get("GROQ_API_KEY")
+    if not groq_key:
+        return None
+    
+    print(f"   [Cloud] Transcribing via Groq Whisper API...")
+    
+    # Compress if needed (Groq limit: 25 MB)
+    audio_path = _compress_audio(audio_path)
+    
+    try:
+        import groq
+        client = groq.Groq(api_key=groq_key)
+        with open(audio_path, "rb") as f:
+            transcription = client.audio.transcriptions.create(
+                file=(audio_path.name, f.read()),
+                model="whisper-large-v3-turbo",
+            )
+        print(f"   [OK] Transcription complete")
+        return transcription.text
+    except Exception as e:
+        print(f"   [ERROR] Groq transcription failed: {e}", file=sys.stderr)
+        return None
+
+
+def _transcribe_local(audio_path: Path) -> str | None:
+    """Transcribe audio using local faster-whisper."""
+    try:
+        from faster_whisper import WhisperModel
+    except ImportError:
+        print("   [WARN]  faster-whisper not installed.")
+        print("   Install: pip install faster-whisper")
+        print("   Or use cloud: set GROQ_API_KEY env var")
+        return None
+    
+    print(f"   [Local] Transcribing via faster-whisper (large-v3)...")
+    print(f"   [WAIT] This may take a while on CPU...")
+    try:
+        model = WhisperModel("large-v3", device="cpu", compute_type="int8")
+        segments, info = model.transcribe(str(audio_path))
+        text_parts = []
+        for seg in segments:
+            text_parts.append(f"[{seg.start:.1f}s] {seg.text.strip()}")
+        print(f"   [OK] Transcription complete ({len(text_parts)} segments)")
+        return "\n".join(text_parts)
+    except Exception as e:
+        print(f"   [ERROR] Local transcription failed: {e}", file=sys.stderr)
+        return None
+
+
+# -- Tier 3: Taddy API -----------------------------------------------
+
+def try_tier3(podcast: dict[str, Any], episode_query: str | None = None) -> str | None:
+    """Try Taddy API for transcript."""
+    api_key = os.environ.get("TADDY_API_KEY")
+    if not api_key:
+        print("\n   [WARN]  Tier 3: TADDY_API_KEY not set. Skipping Taddy API.")
+        print("   Get a key at: https://taddy.org")
+        return None
+    
+    print(f"\n   [Tier 3] Querying Taddy API...")
+    
+    # First search for the podcast UUID if not cached
+    podcast_id = podcast.get("id")
+    
+    query = """
+    mutation searchForPodcast($name: String!, $page: Int = 1) {
+        searchForPodcast(name: $name, page: $page) {
+            searchId
+            searchResults {
+                uuid
+                name
+                feedUrl
+            }
+        }
+    }
+    """
+    
+    payload = json.dumps({
+        "query": query,
+        "variables": {"name": podcast["name"]}
+    }).encode()
+    
+    try:
+        req = urllib.request.Request(
+            "https://api.taddy.org",
+            data=payload,
+            headers={
+                "X-API-Key": api_key,
+                "Content-Type": "application/json",
+            },
+        )
+        resp = urllib.request.urlopen(req, timeout=30)
+        data = json.loads(resp.read())
+        
+        results = data.get("data", {}).get("searchForPodcast", {}).get("searchResults", [])
+        if not results:
+            print("   [ERROR] Podcast not found on Taddy")
+            return None
+        
+        podcast_uuid = results[0]["uuid"]
+        
+        # Now fetch the episode transcript
+        ep_query = """
+        query getEpisodes($podcastUuid: ID!, $page: Int = 1, $limit: Int = 50) {
+            getEpisodes(uuid: $podcastUuid, page: $page, limit: $limit) {
+                uuid
+                name
+                transcript
+                audioUrl
+            }
+        }
+        """
+        
+        ep_payload = json.dumps({
+            "query": ep_query,
+            "variables": {"podcastUuid": podcast_uuid, "limit": 50}
+        }).encode()
+        
+        req2 = urllib.request.Request(
+            "https://api.taddy.org",
+            data=ep_payload,
+            headers={
+                "X-API-Key": api_key,
+                "Content-Type": "application/json",
+            },
+        )
+        resp2 = urllib.request.urlopen(req2, timeout=30)
+        ep_data = json.loads(resp2.read())
+        
+        episodes = ep_data.get("data", {}).get("getEpisodes", [])
+        if not episodes:
+            print("   [ERROR] No episodes found on Taddy")
+            return None
+        
+        # Match episode
+        ep = find_episode(
+            [{"title": e.get("name", ""), "guid": e.get("uuid", ""),
+              "pub_date": "", "description": "", "link": "", "audio_url": None}
+             for e in episodes],
+            episode_query
+        )
+        if ep is None:
+            print("   [ERROR] Episode not found on Taddy")
+            return None
+        
+        # Find the matching episode data
+        for e in episodes:
+            if e.get("uuid") == ep["guid"] or e.get("name") == ep["title"]:
+                transcript = e.get("transcript")
+                if transcript:
+                    print(f"   [OK] Found transcript for: {e['name']}")
+                    return transcript
+                print("   [WARN]  Episode found but no transcript available on Taddy")
+                return None
+        
+        return None
+        
+    except Exception as e:
+        print(f"   [ERROR] Taddy API failed: {e}", file=sys.stderr)
+        return None
+
+
+# -- Output ----------------------------------------------------------
+
+def output_transcript(text: str, podcast_name: str, episode_title: str | None, output_file: str | None = None):
+    """Print or save the transcript."""
+    if not text:
+        print("\n[ERROR] No transcript found.", file=sys.stderr)
+        return False
+    
+    header = f"== Transcript: {podcast_name}"
+    if episode_title:
+        header += f" -- {episode_title}"
+    header += f"\n{'=' * 60}\n"
+    
+    content = header + text + "\n"
+    
+    if output_file:
+        path = Path(output_file)
+        path.write_text(content, encoding="utf-8")
+        print(f"\n[OK] Transcript saved to: {path.resolve()}")
+    else:
+        print(content)
+    
+    return True
+
+
+# -- CLI -------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Fetch transcripts from 5 supported podcasts using 3-tier approach.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s "Lenny's Podcast" --latest
+  %(prog)s 20vc --episode "Marc Andreessen"
+  %(prog)s dwarkesh --episode 15
+  %(prog)s "cheeky pint" --latest --method whisper
+  %(prog)s a16z --latest --output transcript.md
+  %(prog)s --list-podcasts
+        """,
+    )
+    parser.add_argument("podcast", nargs="?", help="Podcast name, slug, or partial match")
+    parser.add_argument("--episode", "-e", default=None, help="Episode: title, number, or 'latest'")
+    parser.add_argument("--latest", "-l", action="store_true", help="Get latest episode")
+    parser.add_argument("--last", type=int, default=None, metavar="N",
+                        help="Batch-transcribe last N episodes into output/ directory")
+    parser.add_argument("--search", "-s", default=None, metavar="QUERY",
+                        help="Search episodes by keyword in title/description across all podcasts")
+    parser.add_argument("--guest", "-g", default=None, metavar="NAME",
+                        help="Search episodes by guest name (alias for --search)")
+    parser.add_argument("--transcribe", action="store_true",
+                        help="With --search/--guest: auto-transcribe top matching episodes instead of listing")
+    parser.add_argument("--transcribe-count", type=int, default=3, metavar="N",
+                        help="Max episodes to transcribe in search pipeline (default: 3)")
+    parser.add_argument("--method", "-m", choices=["auto", "tier1", "whisper", "taddy"], default="auto",
+                        help="Transcription method (default: auto = try all tiers)")
+    parser.add_argument("--output", "-o", default=None, help="Save transcript to file")
+    parser.add_argument("--list-podcasts", action="store_true", help="List available podcasts")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    
+    args = parser.parse_args()
+    registry = load_registry()
+    
+    # -- Feature: Search/guest across podcasts -----------------------
+    if args.search or args.guest:
+        podcasts = registry["podcasts"]
+        term = args.search or args.guest or ""
+        # If podcast name is given, filter to that podcast
+        podcast_filter = args.podcast if args.podcast else None
+        
+        auto_transcribe = args.transcribe
+        _run_search_pipeline(registry, args.search, args.guest,
+                             podcast_filter, auto_transcribe, args.transcribe_count)
+        return
+    
+    # -- Feature: Batch transcribe last N (requires podcast + --last) -
+    if args.last is not None:
+        if not args.podcast:
+            print("[ERROR] --last requires a podcast name.")
+            sys.exit(1)
+        podcast = find_podcast(args.podcast, registry)
+        if not podcast:
+            print(f"[ERROR] Podcast '{args.podcast}' not found.")
+            list_podcasts(registry)
+            sys.exit(1)
+        rss_urls = _get_rss_urls(podcast)
+        if not rss_urls:
+            print(f"[ERROR] No RSS feeds for {podcast['name']}")
+            sys.exit(1)
+        episodes = fetch_rss_cached(rss_urls[0])
+        if not episodes:
+            print(f"[ERROR] No episodes found via RSS for {podcast['name']}")
+            sys.exit(1)
+        batch_transcribe(podcast, args.last, episodes)
+        return
+    
+    # -- Feature: List podcasts --------------------------------------
+    if args.list_podcasts:
+        list_podcasts(registry, as_json=args.json)
+        return
+    
+    # -- Core: single-episode transcript -----------------------------
+    if not args.podcast:
+        parser.print_help()
+        return
+    
+    podcast = find_podcast(args.podcast, registry)
+    if not podcast:
+        print(f"[ERROR] Podcast '{args.podcast}' not found.")
+        print("   Available podcasts:")
+        list_podcasts(registry)
+        sys.exit(1)
+    
+    episode_query = args.episode or ("latest" if args.latest else None)
+    
+    print(f"\nGetting transcript for: {podcast['name']}")
+    if episode_query and episode_query != "latest":
+        print(f"   Episode query: {episode_query}")
+    elif episode_query == "latest":
+        print(f"   Episode: latest")
+    
+    transcript = None
+    
+    if args.method in ("auto", "tier1"):
+        transcript = try_tier1(podcast, episode_query)
+    
+    if not transcript and args.method in ("auto", "whisper"):
+        transcript = try_tier2(podcast, episode_query)
+    
+    if not transcript and args.method in ("auto", "taddy"):
+        transcript = try_tier3(podcast, episode_query)
+    
+    if transcript:
+        output_transcript(transcript, podcast["name"], episode_query, args.output)
+    else:
+        if args.method == "auto":
+            print(f"\n[ERROR] Could not fetch transcript for {podcast['name']}.")
+            print("   Tips:")
+            print("   - For GitHub archive podcasts (Lenny's): clone the repo manually")
+            print("   - Set GROQ_API_KEY for cloud Whisper transcription")
+            print("   - Set TADDY_API_KEY for commercial API access")
+        sys.exit(1 if not transcript else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/podcast-transcript-fetcher/scripts/get_transcript.py
+++ b/skills/podcast-transcript-fetcher/scripts/get_transcript.py
@@ -25,7 +25,9 @@ import tempfile
 import time
 import urllib.request
 import urllib.error
+import urllib.parse
 import xml.etree.ElementTree as ET
+import html
 from pathlib import Path
 from typing import Any
 
@@ -409,14 +411,14 @@ def _transcribe_job(
         job_type: Label for logging (e.g. "Batch" or "Search").
         podcast_name: Display name of the podcast.
         ep: Episode dict with title, pub_date, link, audio_url.
-        index: 0-based index for round-robin key selection and filename.
+        index: 1-based index for progress display and filename.
         total: Total count for progress display.
         api_keys: List of GROQ API keys for round-robin.
     
     Returns:
         True if the episode was successfully transcribed and saved, False otherwise.
     """
-    ep_title = ep.get("title") or f"Episode {index + 1}"
+    ep_title = ep.get("title") or f"Episode {index}"
     pub_date = ep.get("pub_date") or ""
     episode_url = ep.get("link") or ep.get("guid") or ""
     audio_url = ep.get("audio_url") or ""
@@ -425,7 +427,7 @@ def _transcribe_job(
         print(f"   [{job_type}] [SKIP] {ep_title} - no audio URL")
         return False
 
-    output_path = _auto_filename(podcast_name, ep_title, pub_date, index + 1)
+    output_path = _auto_filename(podcast_name, ep_title, pub_date, index)
     if output_path.exists():
         print(f"   [{job_type}] [SKIP] Already exists: {output_path.name}")
         return True  # Count as success since it's already done
@@ -528,6 +530,11 @@ def _run_search_pipeline(
         print("   No search term provided.")
         return
 
+    if podcast_name:
+        matched_podcast = find_podcast(podcast_name, registry)
+        if matched_podcast:
+            podcast_name = matched_podcast["name"]
+
     all_results: list[tuple[str, list[dict[str, Any]]]] = []
 
     for p in registry["podcasts"]:
@@ -625,34 +632,372 @@ def download_audio(url: str, output_path: Path) -> bool:
 
 # -- Tier 1: Direct Sources ------------------------------------------
 
+def _episode_matches_query(title: str, episode_query: str | None) -> bool:
+    if not episode_query or episode_query == "latest":
+        return True
+    query_lower = episode_query.lower().strip()
+    title_lower = title.lower()
+    if query_lower in title_lower:
+        return True
+    num_match = re.search(r"(\d+)", query_lower)
+    if num_match:
+        num = num_match.group(1)
+        if f"episode {num}" in title_lower or f"#{num}" in title:
+            return True
+    return False
+
+
+def _fetch_rss_for_tier1(podcast: dict[str, Any]) -> list[dict[str, Any]] | None:
+    rss_urls = _get_rss_urls(podcast)
+    if not rss_urls:
+        return None
+    return fetch_rss_cached(rss_urls[0])
+
+
+def _try_github_archive(source: dict[str, Any]) -> None:
+    print(f"   -> GitHub archive: {source.get('repo')} (requires local clone, falling through)")
+
+
+def _try_rss_transcript_tag(
+    podcast: dict[str, Any],
+    episode_query: str | None,
+) -> str | None:
+    rss_urls = _get_rss_urls(podcast)
+    if not rss_urls:
+        return None
+    rss_url = rss_urls[0]
+
+    print(f"   -> Checking RSS <podcast:transcript> tags...")
+    try:
+        req = urllib.request.Request(
+            rss_url,
+            headers={"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"},
+        )
+        raw = urllib.request.urlopen(req, timeout=30).read()
+    except Exception as e:
+        print(f"   [WARN]  RSS fetch for transcript tags failed: {e}")
+        return None
+
+    try:
+        root = ET.fromstring(raw)
+    except ET.ParseError as e:
+        print(f"   [WARN]  RSS parse failed: {e}")
+        return None
+
+    ns = {"podcast": "https://podcastindex.org/namespace/1.0"}
+
+    for item in root.iter("item"):
+        title = item.findtext("title", "")
+        if not _episode_matches_query(title, episode_query):
+            continue
+
+        for trans_elem in item.iterfind("podcast:transcript", ns):
+            trans_url = trans_elem.get("url", "")
+            if not trans_url:
+                continue
+            print(f"   -> Downloading RSS-linked transcript: {trans_url[:80]}...")
+            try:
+                req = urllib.request.Request(trans_url, headers={"User-Agent": "Mozilla/5.0"})
+                content = urllib.request.urlopen(req, timeout=30).read().decode("utf-8", errors="replace")
+                if content.strip():
+                    trans_type = trans_elem.get("type", "")
+                    if trans_type == "text/html":
+                        content = re.sub(r"<[^>]+>", " ", content)
+                        content = re.sub(r"\s+", " ", content).strip()
+                    if len(content) > 100:
+                        print(f"   [OK] RSS transcript tag returned content ({len(content)} chars)")
+                        return content
+            except Exception as e:
+                print(f"   [WARN]  Could not download RSS transcript: {e}")
+
+    return None
+
+
+def _try_podscripts(
+    source: dict[str, Any],
+    podcast: dict[str, Any],
+    episode_query: str | None,
+) -> str | None:
+    pod_id = source.get("id", podcast.get("id", ""))
+    if not pod_id:
+        return None
+    print(f"   -> Checking PodScripts.co: {pod_id}")
+
+    api_url = f"https://podscripts.co/api/podcasts/{pod_id}/episodes"
+    try:
+        req = urllib.request.Request(api_url, headers={"User-Agent": "Mozilla/5.0", "Accept": "application/json"})
+        resp = urllib.request.urlopen(req, timeout=15)
+        data = json.loads(resp.read())
+    except Exception as e:
+        print(f"   [WARN]  PodScripts API failed: {e}")
+        return None
+
+    episodes_data = data if isinstance(data, list) else data.get("episodes", data.get("data", []))
+    if not episodes_data:
+        print(f"   [WARN]  No episodes returned by PodScripts")
+        return None
+
+    for ep in episodes_data:
+        title = ep.get("title", "")
+        if not _episode_matches_query(title, episode_query):
+            continue
+        transcript_text = ep.get("transcript") or ep.get("text") or ep.get("content") or ""
+        if transcript_text and len(transcript_text) > 200:
+            print(f"   [OK] Found transcript on PodScripts ({len(transcript_text)} chars)")
+            return transcript_text
+
+    print(f"   [WARN]  No matching episode found on PodScripts")
+    return None
+
+
+def _try_website_scrape(
+    episodes: list[dict[str, Any]] | None,
+    episode_query: str | None,
+) -> str | None:
+    if not episodes:
+        return None
+    print(f"   -> Scraping website for transcript...")
+
+    ep = find_episode(episodes, episode_query)
+    if not ep:
+        return None
+
+    ep_url = ep.get("link", "")
+    if not ep_url or ep_url in ("", "#"):
+        print(f"   [WARN]  No episode URL in RSS entry")
+        return None
+
+    print(f"   -> Episode page: {ep_url[:90]}")
+    try:
+        req = urllib.request.Request(
+            ep_url,
+            headers={"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"},
+        )
+        html_content = urllib.request.urlopen(req, timeout=30).read().decode("utf-8", errors="replace")
+    except Exception as e:
+        print(f"   [WARN]  Could not fetch episode page: {e}")
+        return None
+
+    patterns = [
+        r'<div[^>]*class="[^"]*transcript[^"]*"[^>]*>(.*?)</div>',
+        r'<section[^>]*class="[^"]*transcript[^"]*"[^>]*>(.*?)</section>',
+        r'<div[^>]*class="[^"]*post-content[^"]*"[^>]*>(.*?)</div>',
+        r'<div[^>]*class="[^"]*entry-content[^"]*"[^>]*>(.*?)</div>',
+        r'<div[^>]*class="[^"]*body[^"]*"[^>]*>(.*?)</div>',
+    ]
+    for pattern in patterns:
+        m = re.search(pattern, html_content, re.DOTALL | re.IGNORECASE)
+        if m:
+            text = re.sub(r"<[^>]+>", "\n", m.group(1))
+            text = html.unescape(text)
+            text = re.sub(r"\n{3,}", "\n\n", text).strip()
+            if len(text) > 200:
+                print(f"   [OK] Found transcript on website ({len(text)} chars)")
+                return text
+
+    text_only = re.sub(r"<[^>]+>", "\n", html_content)
+    text_only = html.unescape(text_only)
+    m = re.search(
+        r"(?:full\s+)?transcript[:：\s]+(.+?)(?:\n\s*\n\s*(?:About|Tags|Share|Listen|Subscribe)|\Z)",
+        text_only, re.DOTALL | re.IGNORECASE,
+    )
+    if m:
+        content = m.group(1).strip()
+        if len(content) > 500:
+            print(f"   [OK] Found transcript via heading marker ({len(content)} chars)")
+            return content
+
+    print(f"   [WARN]  No transcript section found on episode page")
+    return None
+
+
+def _try_dropbox(source: dict[str, Any]) -> str | None:
+    url = source.get("url", "")
+    if not url:
+        return None
+    print(f"   -> Checking Dropbox archive...")
+
+    dl_url = url.replace("www.dropbox.com", "dl.dropbox.com")
+    dl_url += "&dl=1" if "?" in dl_url else "?dl=1"
+
+    try:
+        req = urllib.request.Request(dl_url, headers={"User-Agent": "Mozilla/5.0"})
+        resp = urllib.request.urlopen(req, timeout=30)
+        raw = resp.read()
+        try:
+            text = raw.decode("utf-8", errors="replace")
+            if len(text) > 200 and "transcript" in text.lower()[:500]:
+                print(f"   [OK] Downloaded from Dropbox ({len(text)} chars)")
+                return text
+        except UnicodeDecodeError:
+            pass
+        print(f"   [WARN]  Dropbox file is binary/ZIP -- extract manually")
+        return None
+    except Exception as e:
+        print(f"   [WARN]  Dropbox download failed: {e}")
+    return None
+
+
+def _try_github_gist(source: dict[str, Any]) -> str | None:
+    gist_url = source.get("url", "") or ""
+    if not gist_url or "gist." not in gist_url:
+        print(f"   -> GitHub gist: no direct URL configured (needs manual search)")
+        return None
+
+    print(f"   -> Fetching GitHub gist...")
+    raw_url = gist_url.replace("gist.github.com", "gist.githubusercontent.com")
+    if not raw_url.endswith("/raw"):
+        raw_url = raw_url.rstrip("/") + "/raw"
+    try:
+        req = urllib.request.Request(raw_url, headers={"User-Agent": "Mozilla/5.0"})
+        content = urllib.request.urlopen(req, timeout=15).read().decode("utf-8", errors="replace")
+        if content.strip():
+            print(f"   [OK] Gist fetched ({len(content)} chars)")
+            return content
+    except Exception as e:
+        print(f"   [WARN]  GitHub gist fetch failed: {e}")
+    return None
+
+
+def _try_substack_pdf(
+    episodes: list[dict[str, Any]] | None,
+    episode_query: str | None,
+    podcast: dict[str, Any],
+) -> str | None:
+    if not episodes:
+        return None
+    print(f"   -> Checking Substack for PDF transcript...")
+
+    ep = find_episode(episodes, episode_query)
+    if not ep:
+        return None
+
+    ep_url = ep.get("link", "")
+    substack_url = podcast.get("substack", "")
+    if not ep_url and substack_url:
+        ep_url = substack_url
+    if not ep_url:
+        return None
+
+    print(f"   -> Substack page: {ep_url[:80]}")
+    try:
+        req = urllib.request.Request(
+            ep_url,
+            headers={"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"},
+        )
+        html_content = urllib.request.urlopen(req, timeout=30).read().decode("utf-8", errors="replace")
+    except Exception as e:
+        print(f"   [WARN]  Substack fetch failed: {e}")
+        return None
+
+    content_match = re.search(
+        r'<div[^>]*class="[^"]*(?:post-content|body|content)[^"]*"[^>]*>(.*?)</div>\s*</div>',
+        html_content, re.DOTALL,
+    )
+    if content_match:
+        text = re.sub(r"<[^>]+>", "\n", content_match.group(1))
+        text = html.unescape(text)
+        text = re.sub(r"\n{3,}", "\n\n", text).strip()
+        if len(text) > 500:
+            print(f"   [OK] Found inline Substack transcript ({len(text)} chars)")
+            return text
+
+    pdf_links = re.findall(r'href=["\']([^"\']+\.pdf)["\']', html_content)
+    if not pdf_links:
+        print(f"   [WARN]  No PDF or inline transcript on Substack page")
+        return None
+
+    for pdf_url in pdf_links:
+        if not pdf_url.startswith("http"):
+            parsed = urllib.parse.urlparse(ep_url)
+            pdf_url = f"{parsed.scheme}://{parsed.netloc}{pdf_url}"
+        print(f"   -> Downloading PDF: {os.path.basename(pdf_url)}")
+        try:
+            pdf_req = urllib.request.Request(pdf_url, headers={"User-Agent": "Mozilla/5.0"})
+            pdf_data = urllib.request.urlopen(pdf_req, timeout=30).read()
+
+            try:
+                import io as _io
+                import PyPDF2  # type: ignore[import-untyped]
+                reader = PyPDF2.PdfReader(_io.BytesIO(pdf_data))
+                text = "".join(page.extract_text() or "" for page in reader.pages)
+                if text.strip() and len(text) > 200:
+                    print(f"   [OK] Extracted PDF transcript ({len(text)} chars)")
+                    return text
+            except ImportError:
+                pass
+
+            try:
+                import io as _io
+                from pdfminer.high_level import extract_text  # type: ignore[import-untyped]
+                text = extract_text(_io.BytesIO(pdf_data))
+                if text.strip() and len(text) > 200:
+                    print(f"   [OK] Extracted PDF transcript via pdfminer ({len(text)} chars)")
+                    return text
+            except ImportError:
+                pass
+
+            print(f"   [WARN]  No PDF parser installed. pip install PyPDF2 or pdfminer.six")
+            return None
+        except Exception as e:
+            print(f"   [WARN]  PDF download/extraction failed: {e}")
+
+    return None
+
+
 def try_tier1(podcast: dict[str, Any], episode_query: str | None = None) -> str | None:
-    """Try free direct sources for the podcast. Returns transcript or None."""
     sources = podcast.get("transcript_sources", {})
+    if not sources:
+        return None
+
     print(f"\n   [Tier 1] Checking free sources for {podcast['name']}...")
-    
-    # 1a: GitHub archive (Lenny's Podcast)
+
+    rss_episodes: list[dict[str, Any]] | None = None
+
     for source_key, source in sources.items():
         stype = source.get("type", "")
-        
-        if stype == "github_archive" and "repo" in source:
-            print(f"   -> GitHub archive: {source['repo']} (clone separately for Tier 1)")
-            # GitHub archive requires local clone; drop through to try other sources
-        
-        elif stype == "spokenmd_api":
-            api_key = os.environ.get("SPOKENMD_API_KEY", source.get("demo_key", "pt_demo"))
-            print(f"   -> Querying Spoken.md API...")
-            try:
-                req = urllib.request.Request(
-                    f"{source['api_endpoint']}/transcripts",
-                    headers={"Authorization": f"Bearer {api_key}"},
-                )
-                resp = urllib.request.urlopen(req, timeout=15)
-                data = json.loads(resp.read())
-                if data and "transcript" in data:
-                    return data["transcript"]
-            except Exception as e:
-                print(f"   [WARN]  Spoken.md API failed: {e}")
-    
+
+        if stype == "github_archive":
+            _try_github_archive(source)
+
+        elif stype == "dropbox":
+            result = _try_dropbox(source)
+            if result:
+                return result
+
+        elif stype == "podscripts":
+            result = _try_podscripts(source, podcast, episode_query)
+            if result:
+                return result
+
+        elif stype == "github_gist":
+            result = _try_github_gist(source)
+            if result:
+                return result
+
+        elif stype == "rss_transcript_tag":
+            result = _try_rss_transcript_tag(podcast, episode_query)
+            if result:
+                return result
+
+        elif stype in ("website_scrape", "substack_pdf"):
+            if rss_episodes is None:
+                rss_episodes = _fetch_rss_for_tier1(podcast)
+
+            dispatchers = {
+                "website_scrape": _try_website_scrape,
+                "substack_pdf": lambda eps, eq: _try_substack_pdf(eps, eq, podcast),
+            }
+            result = dispatchers[stype](rss_episodes, episode_query)
+            if result:
+                return result
+
+        elif stype == "rss_download_whisper":
+            pass
+
+        else:
+            print(f"   -> Unknown source type '{stype}' -- skipping")
+
     return None
 
 

--- a/skills/podcast-transcript-fetcher/scripts/podcasts.json
+++ b/skills/podcast-transcript-fetcher/scripts/podcasts.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
   "updated": "2026-06-30",
-  "description": "Podcast registry for the podcast-transcript-fetcher skill. Maps each podcast to its RSS feeds, transcript sources, and known archives.",
+  "description": "Podcast registry for the podcast-transcript skill. Maps each podcast to its RSS feeds, transcript sources, and known archives.",
   "podcasts": [
     {
       "id": "lennys-podcast",
@@ -67,20 +67,13 @@
       "host": "Multiple hosts",
       "website": "https://thecheekypint.com",
       "rss": "https://feeds.transistor.fm/cheeky-pint-with-john-collison",
-      "transcript_sources": {
-        "primary": {
-          "type": "spokenmd_api",
-          "description": "Spoken.md API with pt_demo key",
-          "api_endpoint": "https://api.spoken.md/v1",
-          "api_key_var": "SPOKENMD_API_KEY",
-          "demo_key": "pt_demo"
+        "transcript_sources": {
+          "primary": {
+            "type": "rss_download_whisper",
+            "description": "Download audio from RSS, transcribe with Whisper",
+            "note": "Free fallback, needs compute"
+          }
         },
-        "secondary": {
-          "type": "rss_download_whisper",
-          "description": "Download audio from RSS, transcribe with Whisper",
-          "note": "Free fallback, needs compute"
-        }
-      },
       "search_pattern": "cheeky pint {episode}"
     },
     {
@@ -92,17 +85,11 @@
       "rss": "https://feeds.libsyn.com/61840/rss",
       "transcript_sources": {
         "primary": {
-          "type": "youtube_transcript",
-          "description": "199+ YouTube episode transcripts",
-          "url": "https://github.com/sboghossian/20vc-claude-skill",
-          "note": "Existing Claude Code skill with pre-extracted transcripts"
-        },
-        "secondary": {
           "type": "rss_download_whisper",
           "description": "Download audio from RSS, transcribe with Whisper",
           "note": "Hosted on Libsyn (12MB feed, 1476+ episodes)"
         },
-        "tertiary": {
+        "secondary": {
           "type": "substack_pdf",
           "description": "Some episodes have PDF transcripts on Substack",
           "url": "https://20vc.substack.com"

--- a/skills/podcast-transcript-fetcher/scripts/podcasts.json
+++ b/skills/podcast-transcript-fetcher/scripts/podcasts.json
@@ -1,0 +1,161 @@
+{
+  "version": "1.0.0",
+  "updated": "2026-06-30",
+  "description": "Podcast registry for the podcast-transcript skill. Maps each podcast to its RSS feeds, transcript sources, and known archives.",
+  "podcasts": [
+    {
+      "id": "lennys-podcast",
+      "name": "Lenny's Podcast",
+      "slug": "lennys-podcast",
+      "host": "Lenny Rachitsky",
+      "website": "https://www.lennyspodcast.com",
+      "rss": "https://api.substack.com/feed/podcast/10845.rss",
+      "substack": "https://lennyspodcast.substack.com",
+      "transcript_sources": {
+        "primary": {
+          "type": "github_archive",
+          "repo": "ChatPRD/lennys-podcast-transcripts",
+          "description": "269+ pre-transcribed episodes in Markdown",
+          "url": "https://github.com/ChatPRD/lennys-podcast-transcripts"
+        },
+        "secondary": {
+          "type": "dropbox",
+          "description": "Official transcript archive linked from Substack",
+          "url": "https://www.dropbox.com/scl/fo/.../transcripts"
+        },
+        "tertiary": {
+          "type": "rss_transcript_tag",
+          "description": "Some episodes have <podcast:transcript> in RSS",
+          "format": "text/html"
+        }
+      },
+      "search_pattern": "lenny's podcast {episode}"
+    },
+    {
+      "id": "dwarkesh-podcast",
+      "name": "Dwarkesh Podcast",
+      "slug": "dwarkesh-podcast",
+      "host": "Dwarkesh Patel",
+      "website": "https://www.dwarkesh.com",
+      "rss": "https://api.substack.com/feed/podcast/69345.rss",
+      "substack": "https://dwarkesh.substack.com",
+      "transcript_sources": {
+        "primary": {
+          "type": "website_scrape",
+          "description": "Transcripts available on individual episode pages",
+          "url": "https://www.dwarkesh.com",
+          "pattern": "Each episode page has a transcript section"
+        },
+        "secondary": {
+          "type": "podscripts",
+          "id": "dwarkesh-podcast",
+          "description": "Indexed on PodScripts.co",
+          "url": "https://podscripts.co/podcasts/dwarkesh-podcast"
+        },
+        "tertiary": {
+          "type": "github_gist",
+          "description": "Some transcripts posted as GitHub gists",
+          "note": "Search for 'dwarkesh transcript' on GitHub"
+        }
+      },
+      "search_pattern": "dwarkesh {episode} transcript"
+    },
+    {
+      "id": "cheeky-pint",
+      "name": "The Cheeky Pint",
+      "slug": "cheeky-pint",
+      "host": "Multiple hosts",
+      "website": "https://thecheekypint.com",
+      "rss": "https://feeds.transistor.fm/cheeky-pint-with-john-collison",
+      "transcript_sources": {
+        "primary": {
+          "type": "spokenmd_api",
+          "description": "Spoken.md API with pt_demo key",
+          "api_endpoint": "https://api.spoken.md/v1",
+          "api_key_var": "SPOKENMD_API_KEY",
+          "demo_key": "pt_demo"
+        },
+        "secondary": {
+          "type": "rss_download_whisper",
+          "description": "Download audio from RSS, transcribe with Whisper",
+          "note": "Free fallback, needs compute"
+        }
+      },
+      "search_pattern": "cheeky pint {episode}"
+    },
+    {
+      "id": "20vc",
+      "name": "20 Minutes VC (20VC)",
+      "slug": "20vc",
+      "host": "Harry Stebbings",
+      "website": "https://20vc.com",
+      "rss": "https://feeds.libsyn.com/61840/rss",
+      "transcript_sources": {
+        "primary": {
+          "type": "youtube_transcript",
+          "description": "199+ YouTube episode transcripts",
+          "url": "https://github.com/sboghossian/20vc-claude-skill",
+          "note": "Existing Claude Code skill with pre-extracted transcripts"
+        },
+        "secondary": {
+          "type": "rss_download_whisper",
+          "description": "Download audio from RSS, transcribe with Whisper",
+          "note": "Hosted on Libsyn (12MB feed, 1476+ episodes)"
+        },
+        "tertiary": {
+          "type": "substack_pdf",
+          "description": "Some episodes have PDF transcripts on Substack",
+          "url": "https://20vc.substack.com"
+        }
+      },
+      "search_pattern": "20vc {episode} transcript"
+    },
+    {
+      "id": "a16z",
+      "name": "A16z Podcast",
+      "slug": "a16z-podcast",
+      "host": "Andreessen Horowitz",
+      "website": "https://a16z.com/podcasts",
+      "rss": "https://feeds.simplecast.com/JGE3yC0V",
+      "transcript_sources": {
+        "primary": {
+          "type": "podscripts",
+          "id": "a16z-podcast",
+          "description": "Indexed on PodScripts.co",
+          "url": "https://podscripts.co/podcasts/a16z-podcast"
+        },
+        "secondary": {
+          "type": "website_scrape",
+          "description": "Some episodes have transcripts on a16z.com",
+          "url": "https://a16z.com/podcasts"
+        }
+      },
+      "search_pattern": "a16z podcast {episode}"
+    }
+  ],
+  "taddy": {
+    "description": "Taddy API covers all 5 podcasts with auto-transcription for top 5000 shows",
+    "api_endpoint": "https://api.taddy.org",
+    "api_key_var": "TADDY_API_KEY",
+    "plans": {
+      "free": "500 req/month",
+      "pro": "$75/mo = 100k req + 100 transcripts",
+      "business": "$150/mo = 350k req + 2000 transcripts"
+    }
+  },
+  "whisper": {
+    "description": "Local or cloud Whisper transcription as fallback",
+    "local": {
+      "tool": "faster-whisper",
+      "model": "large-v3",
+      "ram": "~5GB",
+      "speed": "~1.5x realtime"
+    },
+    "cloud": {
+      "provider": "Groq",
+      "api_key_var": "GROQ_API_KEY",
+      "model": "whisper-large-v3",
+      "speed": "~10s per hour of audio (free tier generous)"
+    }
+  }
+}

--- a/skills/podcast-transcript-fetcher/scripts/podcasts.json
+++ b/skills/podcast-transcript-fetcher/scripts/podcasts.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
   "updated": "2026-06-30",
-  "description": "Podcast registry for the podcast-transcript skill. Maps each podcast to its RSS feeds, transcript sources, and known archives.",
+  "description": "Podcast registry for the podcast-transcript-fetcher skill. Maps each podcast to its RSS feeds, transcript sources, and known archives.",
   "podcasts": [
     {
       "id": "lennys-podcast",


### PR DESCRIPTION
## Summary

Adds the podcast-transcript-fetcher skill to the OpenDirectory registry with Tier 2 (RSS+Groq Whisper) as the recommended approach.

## What's included

- scripts/get_transcript.py - Core CLI with 3 tiers (best-effort free sources, recommended RSS+Whisper, premium Taddy API)
- scripts/podcasts.json - Registry of 5 podcasts with RSS feeds and transcript sources
- references/podcasts.md - Detailed source documentation
- Cross-podcast search (--search, --guest)
- Batch transcription (--last N) with parallel workers (--parallel N)
- Search-to-transcribe pipeline (--search --transcribe)
- Parallel transcription via ThreadPoolExecutor (--parallel flag, default 1)
- Multi-key GROQ API support (GROQ_API_KEY, GROQ_API_KEY_2, ...) with round-robin assignment
- RSS caching for performance

## Cleanup changes

- Removed broken free sources: youtubetranscript.com (returned HTML), Spoken.md API (paid, no key), YouTube transcript handler (dead code)
- Tier 2 (RSS+Groq Whisper) is now the recommended approach - fast, free, and works for all 5 podcasts
- Tier 1 sources are best-effort (limited to GitHub archive for Lenny's)
- Tier 3 (Taddy API) remains as commercial/premium option for large-scale needs
- Updated README and SKILL.md to reflect the new tier recommendations

## Fixes included

- find_episode() returns None on miss instead of crashing with episodes[0]
- Search pipeline deduplication uses correct 'link' field instead of 'url'
- Search pipeline filename index uses idx+1 instead of len(picked) (prevents collision)
- podcast_filter in search pipeline resolves via find_podcast() so aliases work
- try_tier1 github_archive no longer early-returns
- try_tier2 cleans up temp directory in finally block
- _transcribe_groq() prints explicit error when GROQ_API_KEY is missing
- podcasts.json description corrected to 'podcast-transcript-fetcher'

## Testing

- The Cheeky Pint flows directly to Tier 2 (RSS+Groq Whisper) - confirmed working
- 20VC Tier 1 runs cleanly with no errors or warnings
- All broken free source code paths removed - no orphan references
- LSP diagnostics clean (only pre-existing Windows stdout.reconfigure warning)

## Category

Research - helps find and retrieve podcast transcript content for analysis.
